### PR TITLE
tweaks for new jax eval_shape api

### DIFF
--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -23,7 +23,7 @@ from functools import wraps
 import jax.numpy as np
 
 from jax.abstract_arrays import ShapedArray
-from jax.interpreters import partial_eval as pe
+from jax import eval_shape
 
 from jax_md import space, smap
 from jax_md.interpolate import spline
@@ -35,7 +35,7 @@ def _canonicalize_displacement_or_metric(displacement_or_metric):
   for dim in range(4):
     try:
       R = ShapedArray((dim,), f32)
-      dR_or_dr = pe.abstract_eval_fun(displacement_or_metric, R, R, t=0)
+      dR_or_dr = eval_shape(displacement_or_metric, R, R, t=0)
       if len(dR_or_dr.shape) == 0:
         return displacement_or_metric
       else:

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -657,8 +657,8 @@ def grid(
 
     # TODO: Delete this once vmap supports kwargs.
     _fn = vmap(partial(fn, species_count=species_count, **kwargs), 0, 0)
-    cell_output_shape = eval_shape(_fn, cell_R, cell_species)
-    output_dimension = cell_output_shape[-1]
+    cell_output_shape_struct = eval_shape(_fn, cell_R, cell_species)
+    output_dimension = cell_output_shape_struct.shape[-1]
 
     _cells_per_iter = cells_per_iter
     if cells_per_iter == -1:


### PR DESCRIPTION
In google/jax#1229 we tweaked the `eval_shape` API to return both shapes and dtypes. This small PR uses the new API!