### PR TITLE
Bond triple

### DIFF
--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from functools import wraps
 
 import jax.numpy as np
+from jax import vmap
 
 from jax_md import space, smap, partition
 from jax_md.interpolate import spline

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -233,6 +233,30 @@ def multiplicative_isotropic_cutoff(fn, r_onset, r_cutoff):
 
   return cutoff_fn
 
+def angular_function(fn):
+  """ Takes a function that acts on the cosine of an angle and promotes it to 
+        act on two vectors, such that the angle between the vectors is the input 
+        to the original function.
+
+  Args:
+    fn: A function that takes an ndarray of cosine's of shape [n,] as well
+      as varargs.
+
+  Returns:
+    A new function that takes 2 ndarrays, both of shape [n, spatial_dimension], 
+    along with the same varargs as fn. This function calculates the ndarray of 
+    shape [n,] representing the cosines of the angles formed by corresponding 
+    vectors, and passes this to fn along with the varargs. 
+  """
+  def calc_costheta(dR1, dR2):
+    return np.dot(dR1,dR2) / (np.linalg.norm(dR1) * np.linalg.norm(dR2))
+
+  @wraps(fn)
+  def angular_fn(dRab, dRbc, *args, **kwargs):
+    costheta = vmap(calc_costheta)(dRab,dRbc)
+    return fn(costheta, *args, **kwargs)
+  return angular_fn
+
 
 def load_lammps_eam_parameters(f):
   """Reads EAM parameters from a LAMMPS file and returns relevant spline fits.

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -56,7 +56,7 @@ def simple_spring_bond(
 
 
 def cos_squared(costheta, epsilon=1, costheta0=1, **unused_kwargs):
-  return (k / f32(2)) * (costheta - costheta0)**2
+  return (epsilon / f32(2)) * (costheta - costheta0)**2
 
 def cos_squared_bond_triple(
     displacement, triple=None, triple_type=None,  epsilon=1, costheta0=1):
@@ -64,7 +64,7 @@ def cos_squared_bond_triple(
   epsilon = np.array(epsilon, f32)
   costheta0 = np.array(costheta0, f32)
   return smap.bond_triple(
-    cos_squared,
+    angular_function(cos_squared),
     displacement,
     triple,
     triple_type,

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -55,6 +55,24 @@ def simple_spring_bond(
     alpha=alpha)
 
 
+def cos_squared(costheta, epsilon=1, costheta0=1, **unused_kwargs):
+  return (k / f32(2)) * (costheta - costheta0)**2
+
+def cos_squared_bond_triple(
+    displacement, triple=None, triple_type=None,  epsilon=1, costheta0=1):
+  """Convenience wrapper to compute energy of cos-squared bond-bending potentials."""
+  epsilon = np.array(epsilon, f32)
+  costheta0 = np.array(costheta0, f32)
+  return smap.bond_triple(
+    cos_squared,
+    displacement,
+    triple,
+    triple_type,
+    epsilon=epsilon,
+    costheta0=costheta0)
+
+
+
 def soft_sphere(dr, sigma=1, epsilon=1, alpha=2, **unused_kwargs):
   """Finite ranged repulsive interaction between soft spheres.
 

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -56,7 +56,10 @@ def simple_spring_bond(
 
 
 def cos_squared(costheta, epsilon=1, costheta0=1, **unused_kwargs):
-  return (epsilon / f32(2)) * (costheta - costheta0)**2
+  """ Simple bond-bending potential 
+  """
+  check_kwargs_time_dependence(unused_kwargs)
+  return (epsilon / f32(2)) * (costheta - costheta0) ** 2
 
 def cos_squared_bond_triple(
     displacement, triple=None, triple_type=None,  epsilon=1, costheta0=1):

--- a/tests/energy_test.py
+++ b/tests/energy_test.py
@@ -140,6 +140,34 @@ class EnergyTest(jtu.JaxTestCase):
       self.assertAllClose(E(R), E_exact, True)
 
 
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {
+          'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),
+          'spatial_dimension': dim,
+          'dtype': dtype
+      } for dim in SPATIAL_DIMENSION
+    for dtype in POSITION_DTYPE))
+  def test_cossquared_bondtriple(self, spatial_dimension, dtype):
+    key = random.PRNGKey(0)
+    disp, _ = space.free()
+    if spatial_dimension == 2:
+      R = np.array([[-1., 0.], [0., 0.], [1., 1.]], dtype=dtype)
+      costheta = np.cos(np.pi/dtype(4.))
+    elif spatial_dimension == 3:
+      R = np.array([[-1., 0., 0.], [0., 0., 0.], [1., 1., 0.]], dtype=dtype)
+      costheta = np.cos(np.pi/dtype(4.))
+    triples = np.array([[0, 1, 2]], np.int32)
+    for _ in range(STOCHASTIC_SAMPLES):
+      key, e_key, c0_key = random.split(key, 3)
+      epsilon = random.uniform(key, (), minval=0.1, maxval=3.0, dtype=f32)
+      costheta0 = random.uniform(key, (), minval=-1, maxval=1., dtype=f32)
+      E = energy.cos_squared_bond_triple(disp, triples, epsilon = epsilon, costheta0=costheta0)
+      E_exact = dtype( (epsilon / 2.) * (costheta - costheta0) ** 2)
+      self.assertAllClose(E(R), E_exact, True)
+
+
+
   # pylint: disable=g-complex-comprehension
   @parameterized.named_parameters(jtu.cases_from_list(
       {
@@ -226,6 +254,26 @@ class EnergyTest(jtu.JaxTestCase):
         energy.lennard_jones(r_small, sigma, epsilon), True)
       self.assertAllClose(
         E(r_large, sigma, epsilon), np.zeros_like(r_large, dtype=dtype), True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {
+          'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),
+          'spatial_dimension': dim,
+          'dtype': dtype
+      } for dim in SPATIAL_DIMENSION
+    for dtype in POSITION_DTYPE))
+  def test_angular_function(self, spatial_dimension, dtype):
+    key = random.PRNGKey(0)
+    def calc_costheta(dR1, dR2):
+      return np.dot(dR1,dR2) / (np.linalg.norm(dR1) * np.linalg.norm(dR2))
+
+    for _ in range(STOCHASTIC_SAMPLES):
+      key, split = random.split(key)
+      R = random.uniform(split, (3,spatial_dimension), minval=0.0, maxval=10.0, dtype=dtype)
+
+      E = energy.angular_function(energy.cos_squared)
+      dR = R[1:]-R[:-1]
+      self.assertAllClose(E(np.array([dR[0]]),np.array([dR[1]]))[0], energy.cos_squared(calc_costheta(dR[0],dR[1])), True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {


### PR DESCRIPTION
Here is a first attempt at including "bond triples", which are an extension of smap.bond that acts on triples of particles rather than pairs. Unlike smap.bond, where translation and rotation invariance reduces the two positions to just a single length, bond-triple potentials take two vectors: the vector from i to j, and the vector from j to k. Since a common use is for potential that depend only on the angle between these vectors, I have included the helper function energy.angular_function that converts a function that acts only on the cosine of an angle to a function that acts on pairs of vectors. 

I am of course open to all suggestions, especially when it comes to naming :) 