### PR TITLE
First pass adding colab visualization code to JAX MD.

### DIFF
--- a/jax_md/__init__.py
+++ b/jax_md/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax_md import colab_tools
 from jax_md import space
 from jax_md import energy
 from jax_md import minimize
@@ -23,3 +22,5 @@ from jax_md import dataclasses
 from jax_md import nn
 from jax_md import interpolate
 from jax_md import util
+try:
+  from jax_md import colab_tools

--- a/jax_md/__init__.py
+++ b/jax_md/__init__.py
@@ -22,5 +22,9 @@ from jax_md import dataclasses
 from jax_md import nn
 from jax_md import interpolate
 from jax_md import util
+
 try:
+  # Attempt to load colab_tools if IPython is installed.
   from jax_md import colab_tools
+except:
+  pass

--- a/jax_md/__init__.py
+++ b/jax_md/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from jax_md import colab_tools
 from jax_md import space
 from jax_md import energy
 from jax_md import minimize

--- a/jax_md/colab_tools/__init__.py
+++ b/jax_md/colab_tools/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax_md.colab_tools import renderer

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -72,7 +72,7 @@ class Disk:
 
 @dataclasses.dataclass
 class Sphere:
-   """Sphere geometry elements.
+  """Sphere geometry elements.
 
   Args:
     position: An array of shape `(steps, count, dim)` or `(count, dim)` 

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -1,0 +1,223 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+  import IPython
+  from IPython.display import HTML, display
+
+  import base64
+
+  from google.colab import output
+
+  import numpy as onp
+
+  import time
+
+  renderer_code = IPython.display.HTML(url=('https://raw.githubusercontent.com/'
+                                            'google/jax-md/visualization_2/jax_md/'
+                                            'colab_tools/visualization.html'))
+
+  SIMULATION_IDX = 0
+
+  @dataclasses.dataclass
+  class Disk:
+    position: np.ndarray
+    size: np.ndarray
+    color: np.ndarray
+    count: int = dataclasses.static_field()
+
+    def __init__(self, position, diameter=1.0, color=None):
+      if color is None:
+        color = np.array([0.8, 0.8, 1.0])
+      
+      object.__setattr__(self, 'position', position)
+      object.__setattr__(self, 'size', diameter)
+      object.__setattr__(self, 'color', color)
+      object.__setattr__(self, 'count', position.shape[-2])
+
+    def __repr__(self):
+      return 'Disk'
+
+
+  @dataclasses.dataclass
+  class Sphere:
+    position: np.ndarray
+    size: np.ndarray
+    color: np.ndarray
+    count: int
+
+    def __init__(self, position, diameter=1.0, color=None):
+      if color is None:
+        color = np.array([0.8, 0.8, 1.0])
+      
+      object.__setattr__(self, 'position', position)
+      object.__setattr__(self, 'size', diameter)
+      object.__setattr__(self, 'color', color)
+      object.__setattr__(self, 'count', position.shape[-2])
+
+    def __repr__(self):
+      return 'Sphere'
+
+  @dataclasses.dataclass
+  class Bond:
+    reference_geometry: str
+    neighbor_idx: np.ndarray
+    diameter: np.ndarray
+    color: np.ndarray
+    count: int
+    max_neighbors: int
+
+    def __init__(self, reference_geometry, idx, diameter=1.0, color=None):
+      if color is None:
+        color = np.array([0.8, 0.8, 1.0])
+
+      object.__setattr__(self, 'reference_geometry', reference_geometry)
+      object.__setattr__(self, 'neighbor_idx', idx)
+      object.__setattr__(self, 'diameter', diameter)
+      object.__setattr__(self, 'color', color)
+      object.__setattr__(self, 'count', idx.shape[-2])
+      object.__setattr__(self, 'max_neighbors', idx.shape[-1])
+
+    def __repr__(self):
+      return 'Bond'
+
+
+  TYPE_DIMENSIONS = {
+      'position': 2,
+      'size': 1,
+      'color': 2,
+      'neighbor_idx': 2,
+      'diameter': 1,
+  }
+
+
+  def encode(R):
+    dtype = R.dtype
+    if dtype == np.float64:
+      dtype = np.float32
+    if dtype == np.int64:
+      dtype = np.int32
+    dtype = np.float32
+    return base64.b64encode(onp.array(R, dtype).tobytes()).decode('utf-8')
+
+  import json
+
+  def to_json(data):
+    try:
+      return IPython.display.JSON(data=data)
+    except:
+      return IPython.display.JSON(data=json.dumps(data))
+
+  def render(box_size, 
+            geometry,
+            buffer_size=None, 
+            background_color=None, 
+            resolution=None):
+    global SIMULATION_IDX
+    
+    simulation_idx = SIMULATION_IDX
+
+    frame_count = None
+    dimension = None
+
+    for geom in geometry.values():
+      if hasattr(geom, 'position'):
+        assert dimension is None or goem.position.shape[-1] == dimension
+        dimension = geom.position.shape[-1]
+
+        if geom.position.ndim == 3:
+          assert frame_count is None or frame_count == geom.position.shape[0]
+          frame_count = geom.position.shape[0]
+
+    assert dimension is not None
+
+    if isinstance(box_size, np.ndarray):
+      box_size = float(box_size)
+
+    def get_metadata():
+      metadata = {
+          'box_size': box_size,
+          'dimension': dimension,
+          'geometry': [k for k in geometry.keys()],
+          'simulation_idx': simulation_idx
+      }
+
+      if frame_count is not None:
+        metadata['frame_count'] = frame_count
+
+      if buffer_size is not None:
+        metadata['buffer_size'] = buffer_size
+
+      if background_color is not None:
+        metadata['background_color'] = background_color
+
+      if resolution is not None:
+        metadata['resolution'] = resolution
+
+      return to_json(metadata)
+    output.register_callback('GetSimulationMetadata', get_metadata)
+
+    def get_dynamic_geometry_metadata(name):
+      assert name in geometry
+
+      geom = geometry[name]
+      geom_dict = dataclasses.asdict(geom)
+
+      geom_metadata = {
+          'shape': str(geom),
+          'fields': {},
+      }
+
+      for field in geom_dict:
+        if not isinstance(geom_dict[field], onp.ndarray):
+          geom_metadata[field] = geom_dict[field]
+          continue
+        if len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] + 1:
+          geom_metadata['fields'][field] = 'dynamic'
+        elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field]:
+          geom_metadata['fields'][field] = 'static'
+        elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] - 1:
+          geom_metadata['fields'][field] = 'global'
+      return to_json(geom_metadata)
+    output.register_callback(f'GetGeometryMetadata{SIMULATION_IDX}',
+                            get_dynamic_geometry_metadata)
+
+    def get_array_chunk(name, field, offset, size):
+      assert name in geometry
+
+      geom = dataclasses.asdict(geometry[name])
+      assert field in geom
+      array = geom[field]
+
+      return to_json({
+          'array_chunk': encode(array[offset:(offset + size)])
+      })
+    output.register_callback(f'GetArrayChunk{SIMULATION_IDX}', get_array_chunk)
+
+    def get_array(name, field):
+      assert name in geometry
+
+      geom = dataclasses.asdict(geometry[name])
+      assert field in geom
+      array = geom[field]
+
+      return to_json({ 'array': encode(array) })
+    output.register_callback(f'GetArray{SIMULATION_IDX}', get_array)
+
+    SIMULATION_IDX += 1
+
+    display(renderer_code)
+
+except:
+  pass

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -84,7 +84,7 @@ class Sphere:
       possibly time-varying / per-sphere RGB colors.
     count: The number of spheres.
   """
- position: jnp.ndarray
+  position: jnp.ndarray
   size: jnp.ndarray
   color: jnp.ndarray
   count: int

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -14,13 +14,16 @@
 
 try:
   import IPython
-  from IPython.display import HTML, display
 
   import base64
 
+  import numpy as onp
+
+  import jax.numpy as jnp
+  from jax_md import dataclasses
+
   from google.colab import output
 
-  import numpy as onp
 
   import time
 
@@ -32,14 +35,14 @@ try:
 
   @dataclasses.dataclass
   class Disk:
-    position: np.ndarray
-    size: np.ndarray
-    color: np.ndarray
+    position: jnp.ndarray
+    size: jnp.ndarray
+    color: jnp.ndarray
     count: int = dataclasses.static_field()
 
     def __init__(self, position, diameter=1.0, color=None):
       if color is None:
-        color = np.array([0.8, 0.8, 1.0])
+        color = jnp.array([0.8, 0.8, 1.0])
       
       object.__setattr__(self, 'position', position)
       object.__setattr__(self, 'size', diameter)
@@ -52,14 +55,14 @@ try:
 
   @dataclasses.dataclass
   class Sphere:
-    position: np.ndarray
-    size: np.ndarray
-    color: np.ndarray
+    position: jnp.ndarray
+    size: jnp.ndarray
+    color: jnp.ndarray
     count: int
 
     def __init__(self, position, diameter=1.0, color=None):
       if color is None:
-        color = np.array([0.8, 0.8, 1.0])
+        color = jnp.array([0.8, 0.8, 1.0])
       
       object.__setattr__(self, 'position', position)
       object.__setattr__(self, 'size', diameter)
@@ -72,15 +75,15 @@ try:
   @dataclasses.dataclass
   class Bond:
     reference_geometry: str
-    neighbor_idx: np.ndarray
-    diameter: np.ndarray
-    color: np.ndarray
+    neighbor_idx: jnp.ndarray
+    diameter: jnp.ndarray
+    color: jnp.ndarray
     count: int
     max_neighbors: int
 
     def __init__(self, reference_geometry, idx, diameter=1.0, color=None):
       if color is None:
-        color = np.array([0.8, 0.8, 1.0])
+        color = jnp.array([0.8, 0.8, 1.0])
 
       object.__setattr__(self, 'reference_geometry', reference_geometry)
       object.__setattr__(self, 'neighbor_idx', idx)
@@ -104,11 +107,11 @@ try:
 
   def encode(R):
     dtype = R.dtype
-    if dtype == np.float64:
-      dtype = np.float32
-    if dtype == np.int64:
-      dtype = np.int32
-    dtype = np.float32
+    if dtype == jnp.float64:
+      dtype = jnp.float32
+    if dtype == jnp.int64:
+      dtype = jnp.int32
+    dtype = jnp.float32
     return base64.b64encode(onp.array(R, dtype).tobytes()).decode('utf-8')
 
   import json
@@ -142,7 +145,7 @@ try:
 
     assert dimension is not None
 
-    if isinstance(box_size, np.ndarray):
+    if isinstance(box_size, jnp.ndarray):
       box_size = float(box_size)
 
     def get_metadata():

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -219,5 +219,5 @@ try:
 
     display(renderer_code)
 
-except:
-  pass
+except Exception as e:
+  print(e)

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -12,215 +12,273 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-  import IPython
+"""Kernel-side code for an IPython based visualization tool."""
 
-  import base64
+import base64
 
-  import numpy as onp
+from google.colab import output
 
-  import jax.numpy as jnp
-  from jax_md import dataclasses
+import IPython
 
-  from google.colab import output
+import jax.numpy as jnp
+from jax_md import dataclasses
 
+import json
 
-  import time
+import numpy as onp
 
-  renderer_code = IPython.display.HTML(url=('https://raw.githubusercontent.com/'
-                                            'google/jax-md/visualization_2/jax_md/'
-                                            'colab_tools/visualization.html'))
-
-  SIMULATION_IDX = 0
-
-  @dataclasses.dataclass
-  class Disk:
-    position: jnp.ndarray
-    size: jnp.ndarray
-    color: jnp.ndarray
-    count: int = dataclasses.static_field()
-
-    def __init__(self, position, diameter=1.0, color=None):
-      if color is None:
-        color = jnp.array([0.8, 0.8, 1.0])
-      
-      object.__setattr__(self, 'position', position)
-      object.__setattr__(self, 'size', diameter)
-      object.__setattr__(self, 'color', color)
-      object.__setattr__(self, 'count', position.shape[-2])
-
-    def __repr__(self):
-      return 'Disk'
+import time
 
 
-  @dataclasses.dataclass
-  class Sphere:
-    position: jnp.ndarray
-    size: jnp.ndarray
-    color: jnp.ndarray
-    count: int
+renderer_code = IPython.display.HTML(
+  url=('https://raw.githubusercontent.com/google/jax-md/visualization_2/'
+       'jax_md/colab_tools/visualization.html')
+)
 
-    def __init__(self, position, diameter=1.0, color=None):
-      if color is None:
-        color = jnp.array([0.8, 0.8, 1.0])
-      
-      object.__setattr__(self, 'position', position)
-      object.__setattr__(self, 'size', diameter)
-      object.__setattr__(self, 'color', color)
-      object.__setattr__(self, 'count', position.shape[-2])
-
-    def __repr__(self):
-      return 'Sphere'
-
-  @dataclasses.dataclass
-  class Bond:
-    reference_geometry: str
-    neighbor_idx: jnp.ndarray
-    diameter: jnp.ndarray
-    color: jnp.ndarray
-    count: int
-    max_neighbors: int
-
-    def __init__(self, reference_geometry, idx, diameter=1.0, color=None):
-      if color is None:
-        color = jnp.array([0.8, 0.8, 1.0])
-
-      object.__setattr__(self, 'reference_geometry', reference_geometry)
-      object.__setattr__(self, 'neighbor_idx', idx)
-      object.__setattr__(self, 'diameter', diameter)
-      object.__setattr__(self, 'color', color)
-      object.__setattr__(self, 'count', idx.shape[-2])
-      object.__setattr__(self, 'max_neighbors', idx.shape[-1])
-
-    def __repr__(self):
-      return 'Bond'
+SIMULATION_IDX = 0
 
 
-  TYPE_DIMENSIONS = {
-      'position': 2,
-      'size': 1,
-      'color': 2,
-      'neighbor_idx': 2,
-      'diameter': 1,
-  }
+@dataclasses.dataclass
+class Disk:
+  """Disk geometry elements.
 
+  Args:
+    position: An array of shape `(steps, count, dim)` or `(count, dim)` 
+      specifying possibly time varying positions. Here `dim` is the spatial
+      dimension.
+    size: An array of shape (steps, count)`, `(count,)`, or `()` specifying
+      possibly time-varying / per-disk diameters.
+    color: An array of shape `(steps, count, 3)` or `(count,)` specifying
+      possibly time-varying / per-disk RGB colors.
+    count: The number of disks.
+  """
+  position: jnp.ndarray
+  size: jnp.ndarray
+  color: jnp.ndarray
+  count: int = dataclasses.static_field()
 
-  def encode(R):
-    dtype = R.dtype
-    if dtype == jnp.float64:
-      dtype = jnp.float32
-    if dtype == jnp.int64:
-      dtype = jnp.int32
-    dtype = jnp.float32
-    return base64.b64encode(onp.array(R, dtype).tobytes()).decode('utf-8')
-
-  import json
-
-  def to_json(data):
-    try:
-      return IPython.display.JSON(data=data)
-    except:
-      return IPython.display.JSON(data=json.dumps(data))
-
-  def render(box_size, 
-            geometry,
-            buffer_size=None, 
-            background_color=None, 
-            resolution=None):
-    global SIMULATION_IDX
+  def __init__(self, position, diameter=1.0, color=None):
+    if color is None:
+      color = jnp.array([0.8, 0.8, 1.0])
     
-    simulation_idx = SIMULATION_IDX
+    object.__setattr__(self, 'position', position)
+    object.__setattr__(self, 'size', diameter)
+    object.__setattr__(self, 'color', color)
+    object.__setattr__(self, 'count', position.shape[-2])
 
-    frame_count = None
-    dimension = None
+  def __repr__(self):
+    return 'Disk'
 
-    for geom in geometry.values():
-      if hasattr(geom, 'position'):
-        assert dimension is None or goem.position.shape[-1] == dimension
-        dimension = geom.position.shape[-1]
 
-        if geom.position.ndim == 3:
-          assert frame_count is None or frame_count == geom.position.shape[0]
-          frame_count = geom.position.shape[0]
+@dataclasses.dataclass
+class Sphere:
+   """Sphere geometry elements.
 
-    assert dimension is not None
+  Args:
+    position: An array of shape `(steps, count, dim)` or `(count, dim)` 
+      specifying possibly time varying positions. Here `dim` is the spatial
+      dimension.
+    size: An array of shape (steps, count)`, `(count,)`, or `()` specifying
+      possibly time-varying / per-sphere diameters.
+    color: An array of shape `(steps, count, 3)` or `(count,)` specifying
+      possibly time-varying / per-sphere RGB colors.
+    count: The number of spheres.
+  """
+ position: jnp.ndarray
+  size: jnp.ndarray
+  color: jnp.ndarray
+  count: int
 
-    if isinstance(box_size, jnp.ndarray):
-      box_size = float(box_size)
+  def __init__(self, position, diameter=1.0, color=None):
+    if color is None:
+      color = jnp.array([0.8, 0.8, 1.0])
+    
+    object.__setattr__(self, 'position', position)
+    object.__setattr__(self, 'size', diameter)
+    object.__setattr__(self, 'color', color)
+    object.__setattr__(self, 'count', position.shape[-2])
 
-    def get_metadata():
-      metadata = {
-          'box_size': box_size,
-          'dimension': dimension,
-          'geometry': [k for k in geometry.keys()],
-          'simulation_idx': simulation_idx
-      }
+  def __repr__(self):
+    return 'Sphere'
 
-      if frame_count is not None:
-        metadata['frame_count'] = frame_count
 
-      if buffer_size is not None:
-        metadata['buffer_size'] = buffer_size
+@dataclasses.dataclass
+class Bond:
+  """Bonds are lines between geometric objects.
 
-      if background_color is not None:
-        metadata['background_color'] = background_color
+  Args:
+    reference_geometery: The name of the geometry object to draw bonds between.
+    neighbor_idx: An array of ids of objects that should have bonds drawn 
+      between them. This uses the same encoding as in `partition.neighbor_list`.
+      Essentially, ids is a `(steps, count, max_neighbors)` or 
+      `(count, max_neighbors)` array of integers. `neighbor_idx[i, j] < count`
+      denotes a bond between object `i` and `neighbor[i, j]`.  
+    diameter: The width of the line between the objects.
+    color: An array of shape `(3,)` specifying the RGB color of the bonds.
+    count: The number of objects.
+    max_neighbors: The maximum number of bonds a central object can have.
+  """
+  reference_geometry: str
+  neighbor_idx: jnp.ndarray
+  diameter: jnp.ndarray
+  color: jnp.ndarray
+  count: int
+  max_neighbors: int
 
-      if resolution is not None:
-        metadata['resolution'] = resolution
+  def __init__(self, reference_geometry, idx, diameter=1.0, color=None):
+    if color is None:
+      color = jnp.array([0.8, 0.8, 1.0])
 
-      return to_json(metadata)
-    output.register_callback('GetSimulationMetadata', get_metadata)
+    object.__setattr__(self, 'reference_geometry', reference_geometry)
+    object.__setattr__(self, 'neighbor_idx', idx)
+    object.__setattr__(self, 'diameter', diameter)
+    object.__setattr__(self, 'color', color)
+    object.__setattr__(self, 'count', idx.shape[-2])
+    object.__setattr__(self, 'max_neighbors', idx.shape[-1])
 
-    def get_dynamic_geometry_metadata(name):
-      assert name in geometry
+  def __repr__(self):
+    return 'Bond'
 
-      geom = geometry[name]
-      geom_dict = dataclasses.asdict(geom)
 
-      geom_metadata = {
-          'shape': str(geom),
-          'fields': {},
-      }
+TYPE_DIMENSIONS = {
+    'position': 2,
+    'size': 1,
+    'color': 2,
+    'neighbor_idx': 2,
+    'diameter': 1,
+}
 
-      for field in geom_dict:
-        if not isinstance(geom_dict[field], onp.ndarray):
-          geom_metadata[field] = geom_dict[field]
-          continue
-        if len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] + 1:
-          geom_metadata['fields'][field] = 'dynamic'
-        elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field]:
-          geom_metadata['fields'][field] = 'static'
-        elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] - 1:
-          geom_metadata['fields'][field] = 'global'
-      return to_json(geom_metadata)
-    output.register_callback(f'GetGeometryMetadata{SIMULATION_IDX}',
-                            get_dynamic_geometry_metadata)
 
-    def get_array_chunk(name, field, offset, size):
-      assert name in geometry
+def _encode(R):
+  dtype = R.dtype
+  if dtype == jnp.float64:
+    dtype = jnp.float32
+  if dtype == jnp.int64:
+    dtype = jnp.int32
+  dtype = jnp.float32
+  return base64.b64encode(onp.array(R, dtype).tobytes()).decode('utf-8')
 
-      geom = dataclasses.asdict(geometry[name])
-      assert field in geom
-      array = geom[field]
+def _to_json(data):
+  try:
+    return IPython.display.JSON(data=data)
+  except:
+    return IPython.display.JSON(data=json.dumps(data))
 
-      return to_json({
-          'array_chunk': encode(array[offset:(offset + size)])
-      })
-    output.register_callback(f'GetArrayChunk{SIMULATION_IDX}', get_array_chunk)
+def render(box_size, 
+           geometry,
+           buffer_size=None, 
+           background_color=None, 
+           resolution=None):
+  """Creates a rendering front-end along with callbacks in the host program.
 
-    def get_array(name, field):
-      assert name in geometry
+  Args:
+    box_size: A float or an array of shape `(spatial_dimension,)`. Specifies
+      the size of the simulation volume. Used to position the camera.
+    geometry: A dictionary containing names paired with geometric objects such
+      as Disk, Sphere, or Bond.
+    buffer_size: The maximum number of timesteps to send to the font-end in a
+      single call.
+    background_color: An array of shape (3,) specifying the background color of
+      the visualization.
+    resolution: The resolution of the renderer.
+  """
+  global SIMULATION_IDX
+  
+  simulation_idx = SIMULATION_IDX
 
-      geom = dataclasses.asdict(geometry[name])
-      assert field in geom
-      array = geom[field]
+  frame_count = None
+  dimension = None
 
-      return to_json({ 'array': encode(array) })
-    output.register_callback(f'GetArray{SIMULATION_IDX}', get_array)
+  for geom in geometry.values():
+    if hasattr(geom, 'position'):
+      assert dimension is None or goem.position.shape[-1] == dimension
+      dimension = geom.position.shape[-1]
 
-    SIMULATION_IDX += 1
+      if geom.position.ndim == 3:
+        assert frame_count is None or frame_count == geom.position.shape[0]
+        frame_count = geom.position.shape[0]
 
-    display(renderer_code)
+  assert dimension is not None
 
-except Exception as e:
-  print(e)
+  if isinstance(box_size, jnp.ndarray):
+    if box_size.shape:
+      assert box_size.shape == (dimension,)
+      box_size = list(box_size)
+    else:
+      box_size = [box_size,] * dimension
+  elif isinstance(box_size, float) or isinstance(box_size, int):
+    box_size = [box_size,] * dimension
+
+  def get_metadata():
+    metadata = {
+        'box_size': box_size,
+        'dimension': dimension,
+        'geometry': [k for k in geometry.keys()],
+        'simulation_idx': simulation_idx
+    }
+
+    if frame_count is not None:
+      metadata['frame_count'] = frame_count
+
+    if buffer_size is not None:
+      metadata['buffer_size'] = buffer_size
+
+    if background_color is not None:
+      metadata['background_color'] = background_color
+
+    if resolution is not None:
+      metadata['resolution'] = resolution
+
+    return _to_json(metadata)
+  output.register_callback('GetSimulationMetadata', get_metadata)
+
+  def get_dynamic_geometry_metadata(name):
+    assert name in geometry
+
+    geom = geometry[name]
+    geom_dict = dataclasses.asdict(geom)
+
+    geom_metadata = {
+        'shape': str(geom),
+        'fields': {},
+    }
+
+    for field in geom_dict:
+      if not isinstance(geom_dict[field], onp.ndarray):
+        geom_metadata[field] = geom_dict[field]
+        continue
+      if len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] + 1:
+        geom_metadata['fields'][field] = 'dynamic'
+      elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field]:
+        geom_metadata['fields'][field] = 'static'
+      elif len(geom_dict[field].shape) == TYPE_DIMENSIONS[field] - 1:
+        geom_metadata['fields'][field] = 'global'
+    return _to_json(geom_metadata)
+  output.register_callback(f'GetGeometryMetadata{SIMULATION_IDX}',
+                          get_dynamic_geometry_metadata)
+
+  def get_array_chunk(name, field, offset, size):
+    assert name in geometry
+
+    geom = dataclasses.asdict(geometry[name])
+    assert field in geom
+    array = geom[field]
+
+    return _to_json({
+        'array_chunk': _encode(array[offset:(offset + size)])
+    })
+  output.register_callback(f'GetArrayChunk{SIMULATION_IDX}', get_array_chunk)
+
+  def get_array(name, field):
+    assert name in geometry
+
+    geom = dataclasses.asdict(geometry[name])
+    assert field in geom
+    array = geom[field]
+
+    return _to_json({ 'array': _encode(array) })
+  output.register_callback(f'GetArray{SIMULATION_IDX}', get_array)
+
+  SIMULATION_IDX += 1
+
+  display(renderer_code)

--- a/jax_md/colab_tools/renderer.py
+++ b/jax_md/colab_tools/renderer.py
@@ -205,7 +205,7 @@ def render(box_size,
       assert box_size.shape == (dimension,)
       box_size = list(box_size)
     else:
-      box_size = [box_size,] * dimension
+      box_size = [float(box_size),] * dimension
   elif isinstance(box_size, float) or isinstance(box_size, int):
     box_size = [box_size,] * dimension
 

--- a/jax_md/colab_tools/visualization.html
+++ b/jax_md/colab_tools/visualization.html
@@ -1,0 +1,1021 @@
+<div id='seek'>
+  <button type='button'
+          id='pause_play' 
+          style='width:40px; vertical-align:middle;' 
+          onclick="toggle_play()"> || 
+  </button>
+  <input type="range" 
+         min="0"
+         max="1"
+         value="0"
+         style="width:512px; vertical-align:middle;"
+         class="slider"
+         id="frame_range"
+         oninput='change_frame(this.value)'>
+</div>
+<canvas id="canvas"></canvas>
+<div id='info'> </div>
+<div id='error' style="color:red"> </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
+<script>
+  var DIMENSION;
+
+  var SIZE;
+
+  var SHAPE = {};
+
+  var GEOMETRY = {};
+
+  var CURRENT_FRAME = 0;
+  var FRAME_COUNT = 0;
+
+  var BOX_SIZE;
+  var READ_BUFFER_SIZE = null;
+  var IS_LOADED = false;
+
+  // Info
+
+  var INFO = document.getElementById('info');
+  var ERROR = document.getElementById('error');
+
+  // Graphics
+
+  var GL;
+  var SHADER;
+  var BACKGROUND_COLOR = [0.2, 0.2, 0.2];
+
+  // 3D Camera
+
+  var EYE = mat4.create();
+  var PERSPECTIVE = mat4.create();
+  var LOOK_AT = mat4.create()
+  var YAW = 0.0;
+  var PITCH = 0.0;
+  var CAMERA_POSITION = mat4.create();
+  var Y_ROTATION_MATRIX = mat4.create();
+  var X_ROTATION_MATRIX = mat4.create();
+  var VIEW_DISTANCE = 0.0;
+
+  function make_look_at() {
+    var center = [BOX_SIZE / 2.0, BOX_SIZE / 2.0, BOX_SIZE / 2.0];
+    var direction = [Math.cos(YAW) * Math.cos(PITCH),
+                     Math.sin(PITCH),
+                     Math.sin(YAW) * Math.cos(PITCH)];
+    var pos = [center[0] - VIEW_DISTANCE * direction[0],
+               center[1] - VIEW_DISTANCE * direction[1],
+               center[2] - VIEW_DISTANCE * direction[2]];
+    mat4.lookAt(LOOK_AT, 
+                pos, 
+                center, 
+                [0.0, 1.0, 0.0]);
+  }
+
+  // 2D Camera
+
+  var SCREEN_POSITION = [0, 0];
+  var CAMERA_SIZE = [0, 0];
+
+  // Bonds
+
+  const BOND_SEGMENTS = 3;
+  const VERTICES_PER_BOND = BOND_SEGMENTS * 6;
+
+  // Simulation State
+
+  var IS_PLAYING = true;
+  var PLAY_PAUSE_BUTTON = document.getElementById('pause_play');
+
+  var FRAME_RANGE = document.getElementById('frame_range');
+
+  google.colab.output.setIframeHeight(0, true, {maxHeight: 5000});
+  var invokeFunction = google.colab.kernel.invokeFunction;
+
+  var CANVAS = document.getElementById("canvas");
+  CANVAS.width = 1024;
+  CANVAS.height = 1024;
+
+  // Simulation Loading.
+
+  function make_sizes() {
+    return {
+      position: DIMENSION,
+      angle: DIMENSION - 1,
+      size: 1,
+      color: 3,
+    };
+  }
+
+  function simulation_info_string() {
+    return ('<p style="color:yellow">' +
+            'Simulation Info:</p><div style="padding-left: 20px; padding-bottom: 10px;">' +
+            'Box Size:    ' + BOX_SIZE + '<br>' +
+            'Dimension:   ' + DIMENSION + '<br>' +
+            'Frame Count: ' + FRAME_COUNT + '<br></div>');
+  }
+
+  async function load_simulation() {
+    console.log("Loading simulation."); 
+    INFO.innerHTML = 'Loading simulation...<br>';
+
+    var result = await invokeFunction('GetSimulationMetadata', [], {});
+    var metadata = from_json(result);
+
+    if(!metadata.box_size) {
+      ERROR.innerHTML += 'ERROR: No box size specified.<br>';
+    }
+
+    FRAME_COUNT = metadata.frame_count;
+    BOX_SIZE = metadata.box_size;
+    DIMENSION = metadata.dimension;
+
+    if (metadata.background_color)
+      BACKGROUND_COLOR = metadata.background_color;
+
+    if (metadata.resolution) {
+      CANVAS.width = metadata.resolution[0];
+      CANVAS.height = metadata.resolution[1];
+    }
+
+    const aspect_ratio = CANVAS.width / CANVAS.height;
+
+    INFO.innerHTML += simulation_info_string();
+
+    SIZE = make_sizes();
+    initialize_gl();
+
+    if (DIMENSION == 2) {
+      SCREEN_POSITION = [BOX_SIZE / 2.0, BOX_SIZE / 2.0];
+      CAMERA_SIZE = [aspect_ratio * BOX_SIZE / 2.0, BOX_SIZE / 2.0];
+    } else if (DIMENSION == 3) {
+      const fovy = 45.0 / 180.0 * Math.PI;
+      PERSPECTIVE = mat4.perspective(PERSPECTIVE, 
+                                     fovy,            // Field of view.
+                                     aspect_ratio,    // Aspect ratio.
+                                     BOX_SIZE / 10.0, // Near clip plane.
+                                     100 * BOX_SIZE); // Far clip plane.
+      VIEW_DISTANCE = 2 * BOX_SIZE;
+      make_look_at();
+    } else {
+      ERROR.innerHTML += 'ERROR: Invalid dimension specified: ' + DIMENSION + '.<br>';
+    }
+
+    FRAME_RANGE.max = FRAME_COUNT - 1;
+    console.log(FRAME_RANGE);
+
+    // This specifies the maximum number of frames of data we will try to
+    // transfer between Python and Javascript at a time.
+    READ_BUFFER_SIZE = metadata.buffer_size;
+    if (!READ_BUFFER_SIZE)
+      READ_BUFFER_SIZE = FRAME_COUNT;
+
+    var geometry_list = metadata.geometry;
+    if (geometry_list) {
+      for (var i = 0; i < geometry_list.length ; i++) {
+        const name = geometry_list[i];
+        GEOMETRY[name] = await load_geometry(name);
+      }
+    }
+
+    IS_LOADED = true;
+  }
+
+  async function load_geometry(name) {
+    console.log('Loading ' + name + '.');
+    INFO.innerHTML += 'Loading geometry "' + name + '".<br>';
+    var result = await invokeFunction('GetGeometryMetadata', [name], {});
+    var data = from_json(result);
+
+    console.log(data);
+
+    var geometry = {};
+    geometry.name = name;
+    geometry.shape = data.shape;
+    geometry.count = data.count;
+    geometry.selected = new Int32Array(data.count);
+
+    if (data.reference_geometry)
+      geometry.reference_geometry = data.reference_geometry;
+
+    if (data.max_neighbors)
+      geometry.max_neighbors = data.max_neighbors;
+
+    if(!geometry.shape) {
+      ERROR.innerHTML += 'ERROR: No shape specified for the geometry.<br>';
+    }
+
+    for (var field in data.fields) {
+      var array;
+      var array_type;
+      if (data.fields[field] == 'dynamic') {
+        array = await load_dynamic_array(name, field, geometry.count);
+        array_type = GL.DYNAMIC_DRAW;
+      } else if (data.fields[field] == 'static') {
+        array = await load_array(name, field);
+        array_type = GL.STATIC_DRAW;
+      } else if (data.fields[field] == 'global') {
+        array = await load_array(name, field);
+        array_type = 'GLOBAL';
+      } else {
+        ERROR.innerHTML += ('ERROR: field must have type "dynamic", "static", or ' +
+                            '"global". Found' + data.fields[field] + '.<br>');
+      }
+
+      geometry[field] = array;
+      geometry[field + '_type'] = array_type; 
+
+      if (data.shape == 'Bond' && field == 'neighbor_idx')
+        continue;
+
+      if (array_type != 'GLOBAL') {
+        var array_buffer = GL.createBuffer();
+        var array_buffer_size = 4 * SIZE[field] * geometry.count;
+        GL.bindBuffer(GL.ARRAY_BUFFER, array_buffer);
+        GL.bufferData(GL.ARRAY_BUFFER, array, array_type);
+        geometry[field + '_buffer'] = array_buffer;  
+        geometry[field + '_buffer_size'] = array_buffer_size;   
+      }
+    }
+
+    if (data.shape == 'Bond') {
+      var vertex_buffer = GL.createBuffer();
+      var vertex_count = geometry.count * geometry.max_neighbors * VERTICES_PER_BOND;
+      var vertex_buffer_size = 4 * SIZE['position'] * vertex_count;
+      GL.bindBuffer(GL.ARRAY_BUFFER, vertex_buffer);
+      GL.bufferData(GL.ARRAY_BUFFER, vertex_buffer_size, GL.DYNAMIC_DRAW);
+
+      geometry.vertices = new Float32Array(SIZE['position'] * vertex_count);
+      geometry.vertex_buffer = vertex_buffer;
+      geometry.vertex_buffer_size = vertex_buffer_size;
+
+      var vertex_normal_buffer = GL.createBuffer();
+      GL.bindBuffer(GL.ARRAY_BUFFER, vertex_normal_buffer);
+      GL.bufferData(GL.ARRAY_BUFFER, vertex_buffer_size, GL.DYNAMIC_DRAW);
+
+      geometry.normals = new Float32Array(SIZE['position'] * vertex_count);
+      geometry.vertex_normal_buffer = vertex_normal_buffer;
+    }
+
+    return geometry;
+  }
+
+  async function load_dynamic_array(name, field, count) {
+    if (!FRAME_COUNT) {
+      ERROR.innerHTML += 'ERROR: No frame count specified.<br>';
+    }
+
+    var array = new Float32Array(FRAME_COUNT * count * SIZE[field]);
+
+    const info_text = INFO.innerHTML;
+
+    for (var i = 0 ; i < FRAME_COUNT ; i += READ_BUFFER_SIZE) {
+      await load_array_chunk(name, field, count, array, i, info_text);
+    }
+
+    INFO.innerHTML = info_text + 'Loaded "' + field + '".<br>';
+
+    return array;
+  }
+
+  async function load_array_chunk(name, field, count, array, offset, info_text) {
+    var dbg_string = ('Loading "' + field + '" chunk at time offset ' + offset +
+                      '.<br>'); 
+    console.log(dbg_string);
+    INFO.innerHTML = info_text + dbg_string + '<br>';
+
+    var result = await invokeFunction('GetArrayChunk', 
+                                      [name, field, offset, READ_BUFFER_SIZE],
+                                      {});
+    var data = from_json(result);
+
+    if (!data.array_chunk) {
+      // Error checking.
+    }
+
+    var array_chunk = decode(data.array_chunk);
+    array.set(array_chunk, offset * count * SIZE[field]);
+  }
+
+  async function load_array(name, field) {
+    const info_text = INFO.innerHTML;
+    INFO.innerHTML += 'Loading "' + field + '".<br>';
+    var result = await invokeFunction('GetArray', [name, field], {});
+    var data = from_json(result);
+
+    if (!data.array) {
+      ERROR.innerHTML += 'ERROR: No data array specified.<br>';
+    }
+    INFO.innerHTML = info_text + 'Loaded "' + field + '".<br>';
+    return decode(data.array);
+  }
+
+  function initialize_gl() {
+    GL = CANVAS.getContext("webgl2");
+
+    if (!GL) {
+        alert('Unable to initialize WebGL.');
+        return;
+    }
+
+    GL.viewport(0, 0, GL.drawingBufferWidth, GL.drawingBufferHeight);
+
+    if (BACKGROUND_COLOR)
+      GL.clearColor(BACKGROUND_COLOR[0], 
+                    BACKGROUND_COLOR[1], 
+                    BACKGROUND_COLOR[2], 
+                    1.0);
+    else
+      GL.clearColor(0.2, 0.2, 0.2, 1.0);
+    GL.enable(GL.DEPTH_TEST);
+
+    var shader_program;
+    if (DIMENSION == 2)
+      shader_program = initialize_shader(
+          GL, VERTEX_SHADER_SOURCE_2D, FRAGMENT_SHADER_SOURCE_2D);
+    else if (DIMENSION == 3)
+      shader_program = initialize_shader(
+          GL, VERTEX_SHADER_SOURCE_3D, FRAGMENT_SHADER_SOURCE_3D);
+
+    SHADER = {
+      program: shader_program,
+      attribute: {
+          vertex_position: GL.getAttribLocation(shader_program, 'vertex_position'),
+          position: GL.getAttribLocation(shader_program, 'position'),
+          size: GL.getAttribLocation(shader_program, 'size'),
+          color: GL.getAttribLocation(shader_program, 'color'),
+      },
+      uniform: {
+          color: GL.getUniformLocation(shader_program, 'color'),
+          global_size: GL.getUniformLocation(shader_program, 'global_size'),
+          use_global_size: GL.getUniformLocation(shader_program, 'use_global_size'),
+          global_color: GL.getUniformLocation(shader_program, 'global_color'),
+          use_global_color: GL.getUniformLocation(shader_program, 'use_global_color'),
+          use_position: GL.getUniformLocation(shader_program, 'use_position')
+      },
+    };
+
+    if (DIMENSION == 2) {
+      SHADER.uniform['screen_position'] = GL.getUniformLocation(shader_program, 'screen_position');
+      SHADER.uniform['screen_size'] = GL.getUniformLocation(shader_program, 'screen_size');
+    } else if (DIMENSION == 3) {
+      SHADER.attribute['vertex_normal'] = GL.getAttribLocation(shader_program, 'vertex_normal');
+      SHADER.uniform['perspective'] = GL.getUniformLocation(shader_program, 'perspective');
+      SHADER.uniform['light_direction'] = GL.getUniformLocation(shader_program, 'light_direction');
+    }
+
+    GL.useProgram(shader_program);
+    
+    GL.uniform4f(SHADER.uniform.color, 0.9, 0.9, 1.0, 1.0);
+    GL.uniform1f(SHADER.uniform.global_size, 1.0);
+    GL.uniform1i(SHADER.uniform.use_global_size, true);
+
+    GL.uniform3f(SHADER.uniform.global_color, 1.0, 1.0, 1.0);
+    GL.uniform1i(SHADER.uniform.use_global_color, true);
+    GL.uniform1f(SHADER.uniform.use_position, 1.0);
+
+    var inorm = 1.0 / Math.sqrt(3);
+    GL.uniform3f(SHADER.uniform.light_direction, inorm, -inorm, inorm)
+
+    SHAPE['Disk'] = make_disk(GL, SHADER, 16, 0.5);
+    SHAPE['Sphere'] = make_sphere(GL, SHADER, 16, 16, 0.5);
+
+    const vao = GL.createVertexArray();
+    GL.bindVertexArray(vao);
+  }
+
+  function make_disk(gl, shader, segments, radius) {
+    var position = new Float32Array(segments * DIMENSION * 3);
+    for (var s = 0 ; s < segments ; s++) {
+        const th = 2 * s / segments * Math.PI;
+        const th_p = 2 * (s + 1) / segments * Math.PI;
+        position.set([0.0, 0.0], s * 3 * DIMENSION);
+        position.set([radius * Math.cos(th), radius * Math.sin(th)],
+                     s * 3 * DIMENSION + DIMENSION);
+        position.set([radius * Math.cos(th_p), radius * Math.sin(th_p)], 
+                     s * 3 * DIMENSION + 2 * DIMENSION);
+    }
+
+    var buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, position, gl.STATIC_DRAW);
+
+    return {
+      vertex_position: position,
+      vertex_buffer: buffer,
+      vertex_count: segments * 3,
+    };
+  }
+
+  function make_sphere(gl, shader, horizontal_segments, vertical_segments, radius) {
+    const stride = DIMENSION * 3 * 2;  // 3 vertices per tri, two tris per quad.
+    if (DIMENSION != 3) {
+      return null;
+      // Error Checking.
+    }
+
+    var position = new Float32Array(vertical_segments * horizontal_segments * stride);
+    var normal = new Float32Array(vertical_segments * horizontal_segments * stride);
+
+    var dtheta = 2 * Math.PI / horizontal_segments;
+    var dphi = Math.PI / vertical_segments;
+
+    for (var vs = 0 ; vs < vertical_segments ; vs++) {
+      const phi_0 = vs * dphi;
+      const phi_1 = (vs + 1) * dphi;
+      const offset = vs * horizontal_segments * stride;
+      for (var hs = 0 ; hs < horizontal_segments ; hs++) {
+        const theta_0 = hs * dtheta;
+        const theta_1 = (hs + 1) * dtheta;
+
+        const x0 = radius * Math.sin(phi_0) * Math.cos(theta_0);
+        const y0 = radius * Math.sin(phi_0) * Math.sin(theta_0);
+        const z0 = radius * Math.cos(phi_0);
+
+        const x1 = radius * Math.sin(phi_1) * Math.cos(theta_0);
+        const y1 = radius * Math.sin(phi_1) * Math.sin(theta_0);
+        const z1 = radius * Math.cos(phi_1);
+
+        const x2 = radius * Math.sin(phi_0) * Math.cos(theta_1);
+        const y2 = radius * Math.sin(phi_0) * Math.sin(theta_1);
+        const z2 = radius * Math.cos(phi_0);
+
+        const x3 = radius * Math.sin(phi_1) * Math.cos(theta_1);
+        const y3 = radius * Math.sin(phi_1) * Math.sin(theta_1);
+        const z3 = radius * Math.cos(phi_1);
+
+        position.set([x0, y0, z0,
+                      x1, y1, z1,
+                      x2, y2, z2,
+                      x1, y1, z1,
+                      x3, y3, z3,
+                      x2, y2, z2], offset + hs * stride);
+
+        normal.set([x0 / radius, y0 / radius, z0 / radius,
+                    x1 / radius, y1 / radius, z1 / radius,
+                    x2 / radius, y2 / radius, z2 / radius,
+                    x1 / radius, y1 / radius, z1 / radius,
+                    x3 / radius, y3 / radius, z3 / radius,
+                    x2 / radius, y2 / radius, z2 / radius], offset + hs * stride);              
+      }
+    }
+
+    var buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, position, gl.STATIC_DRAW);
+
+    var normal_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normal_buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, normal, gl.STATIC_DRAW);
+
+    return {
+      vertex_position: position,
+      vertex_buffer: buffer,
+      vertex_normals: normal,
+      vertex_normal_buffer: normal_buffer,
+      vertex_count: vertical_segments * horizontal_segments * 3 * 2
+    };
+  }
+
+  function set_attribute(geometry, name) {
+    if (!geometry[name]) {
+      if (SIZE[name] == 1)
+        GL.uniform1f(SHADER.uniform['global_' + name], 1.0);
+      else if (SIZE[name] == 2)
+        GL.uniform2f(SHADER.uniform['global_' + name], 1.0, 1.0);
+      else if (SIZE[name] == 3)
+        GL.uniform3f(SHADER.uniform['global_' + name], 1.0, 1.0, 1.0);
+
+      GL.uniform1i(SHADER.uniform['use_global_' + name], true);
+    } else if (geometry[name + '_type'] == 'GLOBAL') {
+      if (SIZE[name] == 1)
+        GL.uniform1fv(SHADER.uniform['global_' + name], geometry[name]);
+      else if (SIZE[name] == 2)
+        GL.uniform2fv(SHADER.uniform['global_' + name], geometry[name]);
+      else if (SIZE[name] == 3)
+        GL.uniform3fv(SHADER.uniform['global_' + name], geometry[name]);
+
+      GL.uniform1i(SHADER.uniform['use_global_' + name], true);
+    } else {
+      GL.enableVertexAttribArray(SHADER.attribute[name]);
+      var stride = SIZE[name] * geometry.count;
+      GL.bindBuffer(GL.ARRAY_BUFFER, geometry[name + '_buffer']);
+      if (geometry[name + '_type'] == GL.DYNAMIC_DRAW) {
+        const data = geometry[name].slice(FRAME_COUNT * stride, 
+                                          (FRAME_COUNT + 1) * stride);
+        GL.bufferSubData(GL.ARRAY_BUFFER, 0, data);
+      }
+      GL.vertexAttribPointer(
+        SHADER.attribute[name],               
+        SIZE[name],        
+        GL.FLOAT,         
+        false,            
+        0,    
+        0
+      );                
+      GL.vertexAttribDivisor(SHADER.attribute[name], 1);
+
+      GL.uniform1i(SHADER.uniform['use_global_' + name], false);
+    }
+  }
+
+  var loops = 0;
+
+  function update_frame() {
+    if(!GL) {
+      window.requestAnimationFrame(update_frame);
+      return;
+    }
+
+    GL.clear(GL.COLOR_BUFFER_BIT | GL.DEPTH_BUFFER_BIT);
+    
+    if (!IS_LOADED) {
+      window.requestAnimationFrame(update_frame);
+      return;
+    }
+
+    if (DIMENSION == 2) {
+      var camera_x = SCREEN_POSITION[0];
+      var camera_y = SCREEN_POSITION[1];
+
+      if (DRAGGING) {
+        const delta = get_drag_offset();
+        camera_x += delta[0];
+        camera_y += delta[1];
+      }
+      GL.uniform2f(SHADER.uniform.screen_position, camera_x, camera_y);
+      GL.uniform2f(SHADER.uniform.screen_size, CAMERA_SIZE[0], CAMERA_SIZE[1]);
+    } else if (DIMENSION == 3) {
+
+      // Now these are some janky globals.
+      if (DRAGGING) {
+        var yaw = YAW;
+        var pitch = PITCH;
+        const delta = get_drag_offset();
+        YAW = YAW - delta[0];
+        PITCH = PITCH - delta[1];
+        make_look_at();
+        YAW = yaw;
+        PITCH = pitch;
+      }
+
+      GL.uniformMatrix4fv(SHADER.uniform.perspective, false,
+                          mat4.multiply(EYE, PERSPECTIVE, LOOK_AT));
+    }
+
+    if (CURRENT_FRAME >= FRAME_COUNT - 1) {
+      loops++;
+      CURRENT_FRAME = 0;
+    }
+
+    for (var name in GEOMETRY) {
+      var geom = GEOMETRY[name];
+
+      set_attribute(geom, 'size');
+      set_attribute(geom, 'color');
+
+      var shape = geom.shape;
+      var vertex_buffer;
+      var vertex_count;
+      var vertex_normal_buffer = null;
+
+      if (shape != 'Bond') {
+        shape = SHAPE[shape];
+
+        update_shape(geom);        
+
+        vertex_buffer = shape.vertex_buffer;
+        vertex_count = shape.vertex_count;
+        vertex_normal_buffer = shape.vertex_normal_buffer;
+      } else {
+        vertex_count = update_bond_vertex_data(GEOMETRY[geom.reference_geometry],
+                                               geom);
+        vertex_buffer = geom.vertex_buffer;
+        vertex_normal_buffer = geom.vertex_normal_buffer;
+      }
+
+      GL.enableVertexAttribArray(SHADER.attribute.vertex_position);
+      GL.bindBuffer(GL.ARRAY_BUFFER, vertex_buffer);
+      GL.vertexAttribPointer(
+        SHADER.attribute.vertex_position,
+        DIMENSION,
+        GL.FLOAT,
+        false,
+        0,
+        0
+      );
+
+      if (DIMENSION == 3 && vertex_normal_buffer) { 
+        GL.enableVertexAttribArray(SHADER.attribute.vertex_normal);
+        GL.bindBuffer(GL.ARRAY_BUFFER, vertex_normal_buffer);
+        GL.vertexAttribPointer(
+          SHADER.attribute.vertex_normal,
+          DIMENSION,
+          GL.FLOAT,
+          false,
+          0,
+          0
+        );
+      }
+
+      if (shape == 'Bond')
+      {
+        GL.drawArrays(GL.TRIANGLES, 0, vertex_count);
+      }
+      else {
+        GL.drawArraysInstanced(GL.TRIANGLES, 0, vertex_count, geom.count);
+      }
+    }
+
+    if(IS_PLAYING) {
+      CURRENT_FRAME++;
+      FRAME_RANGE.value = CURRENT_FRAME;
+    }
+
+    window.requestAnimationFrame(update_frame);
+  }
+
+  function update_shape(geometry) {
+    GL.enableVertexAttribArray(SHADER.attribute.position);
+    var stride = geometry.count * DIMENSION;
+    GL.bindBuffer(GL.ARRAY_BUFFER, geometry.position_buffer);
+    if (geometry.position_type == GL.DYNAMIC_DRAW) {
+      const positions = geometry.position.subarray(CURRENT_FRAME * stride, 
+                                                   (CURRENT_FRAME + 1) * stride);
+      GL.bufferSubData(GL.ARRAY_BUFFER, 0, positions);
+    }
+    GL.vertexAttribPointer(
+      SHADER.attribute.position,               
+      DIMENSION,        
+      GL.FLOAT,         
+      false,            
+      0,    
+      0
+    );                
+    GL.vertexAttribDivisor(SHADER.attribute.position, 1);
+    GL.uniform1f(SHADER.uniform.use_position, 1.0);
+  }
+
+  function update_bond_vertex_data(reference_geometry, bonds) {
+    const geom = reference_geometry;
+    const N = geom.count;
+    var stride = N * DIMENSION;
+    const positions = geom.position.subarray(CURRENT_FRAME * stride, 
+                                             (CURRENT_FRAME + 1) * stride);
+    const neighbors = bonds.max_neighbors;
+
+    var vertex_count = 0;
+    var vertices = bonds.vertices;
+    var normals = bonds.normals;
+
+    for (var i = 0 ; i < N ; i++) {
+      var r_i = positions.subarray(i * DIMENSION, (i + 1) * DIMENSION);
+      for (var j = 0 ; j < neighbors ; j++) {
+        const idx = i * neighbors + j; 
+        const nbr_idx = Math.round(bonds.neighbor_idx[idx]);
+
+        if (nbr_idx < i) {
+          var r_j = positions.subarray(nbr_idx * DIMENSION, (nbr_idx + 1) * DIMENSION);
+          vertex_count = push_bond(vertices, normals, vertex_count, r_i, r_j, 0.1); //bonds.diameter / 2.0);
+        }
+      }
+    }
+
+    GL.bindBuffer(GL.ARRAY_BUFFER, bonds.vertex_buffer);
+    GL.bufferData(GL.ARRAY_BUFFER, vertices, GL.DYNAMIC_DRAW);
+
+    GL.bindBuffer(GL.ARRAY_BUFFER, bonds.vertex_normal_buffer);
+    GL.bufferData(GL.ARRAY_BUFFER, normals, GL.DYNAMIC_DRAW);
+
+    GL.uniform1f(SHADER.uniform.use_position, 0.0);
+    GL.uniform1i(SHADER.uniform.use_global_size, 1);
+    GL.uniform1i(SHADER.uniform.use_global_color, 1);
+
+    return vertex_count;
+  }
+
+  BOND_C_TABLE = [];
+  BOND_S_TABLE = [];
+  for (var i = 0 ; i < BOND_SEGMENTS ; i++)
+  {
+    BOND_C_TABLE.push(Math.cos(2 * i * Math.PI / BOND_SEGMENTS));
+    BOND_S_TABLE.push(Math.sin(2 * i * Math.PI / BOND_SEGMENTS));
+  }
+
+  function push_bond(vertices, normals, vertex_count, r_i, r_j, radius) {
+    var dr = vec3.fromValues(r_i[0] - r_j[0], 
+                             r_i[1] - r_j[1], 
+                             r_i[2] - r_j[2]);
+
+    if (Math.abs(dr[0]) > BOX_SIZE / 2.0 || 
+        Math.abs(dr[1]) > BOX_SIZE / 2.0 ||
+        Math.abs(dr[2]) > BOX_SIZE / 2.0 )
+      return vertex_count;
+
+    var up = vec3.fromValues(0.0, 1.0, 0.0);
+    var left = vec3.fromValues(0.0, 1.0, 0.0);
+
+    vec3.cross(left, up, dr);
+    vec3.normalize(left, left);
+
+    vec3.cross(up, left, dr);
+    vec3.normalize(up, up);
+
+    var normal = vec3.fromValues(0.0, 0.0, 0.0);
+ 
+    for (var i = 0 ; i < BOND_SEGMENTS ; i++) {
+      const c1 = radius * BOND_C_TABLE[i];
+      const c2 = radius * BOND_C_TABLE[(i + 1) % BOND_SEGMENTS];
+      const s1 = radius * BOND_S_TABLE[i];
+      const s2 = radius * BOND_S_TABLE[(i + 1) % BOND_SEGMENTS];
+
+      vertices.set([
+        r_j[0] + left[0] * c1 + up[0] * s1,
+        r_j[1] + left[1] * c1 + up[1] * s1,
+        r_j[2] + left[2] * c1 + up[2] * s1,
+
+        r_i[0] + left[0] * c1 + up[0] * s1,
+        r_i[1] + left[1] * c1 + up[1] * s1,
+        r_i[2] + left[2] * c1 + up[2] * s1,
+
+        r_j[0] + left[0] * c2 + up[0] * s2,
+        r_j[1] + left[1] * c2 + up[1] * s2,
+        r_j[2] + left[2] * c2 + up[2] * s2,
+
+        r_i[0] + left[0] * c1 + up[0] * s1,
+        r_i[1] + left[1] * c1 + up[1] * s1,
+        r_i[2] + left[2] * c1 + up[2] * s1,
+
+        r_i[0] + left[0] * c2 + up[0] * s2,
+        r_i[1] + left[1] * c2 + up[1] * s2,
+        r_i[2] + left[2] * c2 + up[2] * s2,
+
+        r_j[0] + left[0] * c2 + up[0] * s2,
+        r_j[1] + left[1] * c2 + up[1] * s2,
+        r_j[2] + left[2] * c2 + up[2] * s2,        
+      ], 3 * (vertex_count + 6 * i));
+
+      vec3.cross(normal, 
+                 [r_j[0] - r_i[0] + left[0] * c1 + up[0] * s1, 
+                  r_j[1] - r_i[1] + left[1] * c1 + up[1] * s1, 
+                  r_j[2] - r_i[2] + left[2] * c1 + up[2] * s1],
+                 [left[0] * (c1 - c2) + up[0] * (s1 - s2), 
+                  left[1] * (c1 - c2) + up[1] * (s1 - s2), 
+                  left[2] * (c1 - c2) + up[2] * (s1 - s2)]);
+      vec3.normalize(normal, normal);
+
+      normals.set([
+        normal[0], normal[1], normal[2],
+        normal[0], normal[1], normal[2],
+        normal[0], normal[1], normal[2],
+        normal[0], normal[1], normal[2],
+        normal[0], normal[1], normal[2],
+        normal[0], normal[1], normal[2],
+      ], 3 * (vertex_count + 6 * i));
+    }
+    return vertex_count + 6 * BOND_SEGMENTS;
+  }
+
+  // SHADER CODE
+
+  const VERTEX_SHADER_SOURCE_2D = `#version 300 es
+    // Vertex Shader Program.
+    in vec2 vertex_position;
+    in vec2 position;
+    in float size;
+    in vec3 color;
+
+    out vec4 v_color;
+
+    uniform float use_position;
+
+    uniform vec2 screen_position;
+    uniform vec2 screen_size;
+
+    uniform float global_size;
+    uniform bool use_global_size;
+
+    uniform vec3 global_color;
+    uniform bool use_global_color;
+
+    void main() {
+      float _size = use_global_size ? global_size : size;
+      vec2 v = (_size * vertex_position + position - screen_position) / screen_size;
+      gl_Position = vec4(v, 0.0, 1.0);
+      v_color = vec4(use_global_color ? global_color : color, 1.0f);
+    }
+  `;
+
+  const FRAGMENT_SHADER_SOURCE_2D = `#version 300 es
+    precision mediump float;
+
+    in vec4 v_color;
+
+    out vec4 outColor;
+
+    void main() {
+      outColor = v_color;
+    }
+  `;
+
+   const VERTEX_SHADER_SOURCE_3D = `#version 300 es
+    // Vertex Shader Program.
+    in vec3 vertex_position;
+    in vec3 vertex_normal;
+
+    in vec3 position;
+    in float size;
+    in vec3 color;
+
+    out vec4 v_color;
+    out vec3 v_normal;
+
+    uniform mat4 perspective;
+
+    uniform float use_position;
+
+    uniform float global_size;
+    uniform bool use_global_size;
+
+    uniform vec3 global_color;
+    uniform bool use_global_color;
+
+    void main() {
+      vec3 pos = use_position * position;
+      float _size = use_global_size ? global_size : size;
+
+      vec3 v = (_size * vertex_position + pos);
+      gl_Position = perspective * vec4(v, 1.0);
+
+      v_color = vec4(use_global_color ? global_color : color, 1.0f);
+      v_normal = vertex_normal;
+    }
+  `;
+
+  const FRAGMENT_SHADER_SOURCE_3D = `#version 300 es
+    precision mediump float;
+
+    in vec4 v_color;
+    in vec3 v_normal;
+
+    uniform vec3 light_direction;
+
+    out vec4 outColor;
+
+    void main() {
+      float diffuse_magnitude = clamp(-dot(v_normal, light_direction), 0.0, 1.0) + 0.2;
+
+      outColor = vec4(vec3(v_color) * diffuse_magnitude, v_color.a);
+    }
+  `;
+
+  function initialize_shader(gl, vertex_shader_source, fragment_shader_source) {
+
+    const vertex_shader = compile_shader(
+      gl, gl.VERTEX_SHADER, vertex_shader_source);
+    const fragment_shader = compile_shader(
+      gl, gl.FRAGMENT_SHADER, fragment_shader_source);
+
+    const shader_program = gl.createProgram();
+    gl.attachShader(shader_program, vertex_shader);
+    gl.attachShader(shader_program, fragment_shader);
+    gl.linkProgram(shader_program);
+
+    if (!gl.getProgramParameter(shader_program, gl.LINK_STATUS)) {
+      alert(
+        'Unable to initialize shader program: ' + 
+        gl.getProgramInfoLog(shader_program)
+        );
+        return null;
+    }
+    return shader_program;
+  }
+
+  function compile_shader(gl, type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      alert('An error occured compiling shader: ' + gl.getShaderInfoLog(shader));
+      gl.deleteShader(shader);
+      return null;
+    }
+
+    return shader;
+  }
+
+  // UI
+
+  var DRAG_START;
+  var DRAG_CURRENT;
+  var DRAGGING = false;
+
+  CANVAS.addEventListener('mousedown', function(e) {
+    DRAG_START = [e.offsetX, e.offsetY];
+    DRAGGING = true;
+  });
+
+  CANVAS.addEventListener('mousemove', function(e) {
+    DRAG_CURRENT = [e.offsetX, e.offsetY];
+  });
+
+  CANVAS.addEventListener('mouseup', function(e) {
+    const delta = get_drag_offset();
+    if (DIMENSION == 2) {
+      SCREEN_POSITION = [SCREEN_POSITION[0] + delta[0],
+                         SCREEN_POSITION[1] + delta[1]];
+    } else if (DIMENSION == 3) {
+      YAW -= delta[0];
+      PITCH -= delta[1];
+
+      if (PITCH > Math.PI / 2.1)
+        PITCH = Math.PI / 2.1;
+      if (PITCH < -Math.PI / 2.1)
+        PITCH = -Math.PI / 2.1;
+
+      make_look_at();
+    }
+
+    DRAGGING = false;
+  });
+
+  function toggle_play() {
+    IS_PLAYING = !IS_PLAYING;
+    console.log(PLAY_PAUSE_BUTTON);
+    if(IS_PLAYING)
+      PLAY_PAUSE_BUTTON.innerHTML = '||';
+    else
+      PLAY_PAUSE_BUTTON.innerHTML = '>';
+  }
+
+  function change_frame(value) {
+    if (!IS_LOADED)
+      return;
+    CURRENT_FRAME = value;
+    FRAME_RANGE.innerHTML = value;
+  }
+
+  function get_drag_offset() {
+    var delta = [DRAG_START[0] - DRAG_CURRENT[0],
+                 -DRAG_START[1] + DRAG_CURRENT[1]];
+    delta = [delta[0] / canvas.width * 2, delta[1] / canvas.height * 2];
+    if (DIMENSION == 2) {
+      delta = [delta[0] * CAMERA_SIZE[0],
+               delta[1] * CAMERA_SIZE[1]];
+    }
+    return delta;
+  }
+
+  const SCALE_SPEED = 0.1;
+  CANVAS.addEventListener('mousewheel', function(e) {
+    var delta = Math.sign(e.wheelDeltaY);
+    if (navigator.appVersion.indexOf('Mac'))
+      delta *= -0.1;
+    if (DIMENSION == 2) {
+      CAMERA_SIZE[0] = CAMERA_SIZE[0] * (1 + delta * SCALE_SPEED);
+      CAMERA_SIZE[1] = CAMERA_SIZE[1] * (1 + delta * SCALE_SPEED);
+    } else if (DIMENSION == 3) {
+      VIEW_DISTANCE = VIEW_DISTANCE * (1 + delta * SCALE_SPEED);
+      make_look_at();
+    }
+    e.preventDefault();
+  }, false);
+  CANVAS.addEventListener('DOMMouseScroll', function(e) {
+    const delta = Math.sign(e.detail);
+    if (DIMENSION == 2) {
+      CAMERA_SIZE[0] = CAMERA_SIZE[0] * (1 + delta * SCALE_SPEED);
+      CAMERA_SIZE[1] = CAMERA_SIZE[1] * (1 + delta * SCALE_SPEED);
+    } else if (DIMENSION == 3) {
+      VIEW_DISTANCE = VIEW_DISTANCE * (1 + delta * SCALE_SPEED);
+      make_look_at();
+    }
+    e.preventDefault();
+  }, false);
+
+
+  // SERIALIZATION UTILITIES
+  function decode(sBase64, nBlocksSize) {
+    var chrs = atob(sBase64);
+    var array = new Uint8Array(new ArrayBuffer(chrs.length));
+
+    for(var i = 0 ; i < chrs.length ; i++) {
+      array[i] = chrs.charCodeAt(i);
+    }
+
+    return new Float32Array(array.buffer);
+  }
+
+  function from_json(data) { 
+    data = data.data['application/json'];
+
+    if (typeof data == 'string') {
+      return JSON.parse(data);
+    }
+
+    return data;
+  }
+
+  // RUN CELL
+
+  load_simulation();
+  update_frame();
+</script>

--- a/jax_md/colab_tools/visualization.html
+++ b/jax_md/colab_tools/visualization.html
@@ -1,4 +1,17 @@
 <!--
+  Copyright 2019 Google LLC
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
   A fragment of HTML and Javascript that describes a visualization tool.
   
   This code is expected to be injected into Jupyter or Colaboratory notebooks using the `IPython.display.HTML` function. The tool is rendered using WebGL2.

--- a/jax_md/colab_tools/visualization.html
+++ b/jax_md/colab_tools/visualization.html
@@ -1,3 +1,9 @@
+<!--
+  A fragment of HTML and Javascript that describes a visualization tool.
+  
+  This code is expected to be injected into Jupyter or Colaboratory notebooks using the `IPython.display.HTML` function. The tool is rendered using WebGL2.
+-->
+
 <div id='seek'>
   <button type='button'
           id='pause_play' 
@@ -17,6 +23,7 @@
 <div id='info'> </div>
 <div id='error' style="color:red"> </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
+
 <script>
   var DIMENSION;
 
@@ -32,6 +39,7 @@
   var BOX_SIZE;
   var READ_BUFFER_SIZE = null;
   var IS_LOADED = false;
+  var SIMULATION_IDX = 0;
 
   // Info
 
@@ -127,6 +135,7 @@
     FRAME_COUNT = metadata.frame_count;
     BOX_SIZE = metadata.box_size;
     DIMENSION = metadata.dimension;
+    SIMULATION_IDX = metadata.simulation_idx;
 
     if (metadata.background_color)
       BACKGROUND_COLOR = metadata.background_color;
@@ -160,7 +169,6 @@
     }
 
     FRAME_RANGE.max = FRAME_COUNT - 1;
-    console.log(FRAME_RANGE);
 
     // This specifies the maximum number of frames of data we will try to
     // transfer between Python and Javascript at a time.
@@ -182,7 +190,8 @@
   async function load_geometry(name) {
     console.log('Loading ' + name + '.');
     INFO.innerHTML += 'Loading geometry "' + name + '".<br>';
-    var result = await invokeFunction('GetGeometryMetadata', [name], {});
+    var result = await invokeFunction('GetGeometryMetadata' + SIMULATION_IDX,
+                                      [name], {});
     var data = from_json(result);
 
     console.log(data);
@@ -238,7 +247,9 @@
 
     if (data.shape == 'Bond') {
       var vertex_buffer = GL.createBuffer();
-      var vertex_count = geometry.count * geometry.max_neighbors * VERTICES_PER_BOND;
+      var vertex_count = (geometry.count * 
+                          geometry.max_neighbors * 
+                          VERTICES_PER_BOND);
       var vertex_buffer_size = 4 * SIZE['position'] * vertex_count;
       GL.bindBuffer(GL.ARRAY_BUFFER, vertex_buffer);
       GL.bufferData(GL.ARRAY_BUFFER, vertex_buffer_size, GL.DYNAMIC_DRAW);
@@ -282,7 +293,7 @@
     console.log(dbg_string);
     INFO.innerHTML = info_text + dbg_string + '<br>';
 
-    var result = await invokeFunction('GetArrayChunk', 
+    var result = await invokeFunction('GetArrayChunk' + SIMULATION_IDX, 
                                       [name, field, offset, READ_BUFFER_SIZE],
                                       {});
     var data = from_json(result);
@@ -298,7 +309,8 @@
   async function load_array(name, field) {
     const info_text = INFO.innerHTML;
     INFO.innerHTML += 'Loading "' + field + '".<br>';
-    var result = await invokeFunction('GetArray', [name, field], {});
+    var result = await invokeFunction('GetArray' + SIMULATION_IDX,
+                                      [name, field], {});
     var data = from_json(result);
 
     if (!data.array) {

--- a/jax_md/colab_tools/visualization.html
+++ b/jax_md/colab_tools/visualization.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2020 Google LLC
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
@@ -78,7 +78,7 @@
   var VIEW_DISTANCE = 0.0;
 
   function make_look_at() {
-    var center = [BOX_SIZE / 2.0, BOX_SIZE / 2.0, BOX_SIZE / 2.0];
+    var center = [BOX_SIZE[0] / 2.0, BOX_SIZE[1] / 2.0, BOX_SIZE[2] / 2.0];
     var direction = [Math.cos(YAW) * Math.cos(PITCH),
                      Math.sin(PITCH),
                      Math.sin(YAW) * Math.cos(PITCH)];
@@ -166,16 +166,17 @@
     initialize_gl();
 
     if (DIMENSION == 2) {
-      SCREEN_POSITION = [BOX_SIZE / 2.0, BOX_SIZE / 2.0];
-      CAMERA_SIZE = [aspect_ratio * BOX_SIZE / 2.0, BOX_SIZE / 2.0];
+      SCREEN_POSITION = [BOX_SIZE[0] / 2.0, BOX_SIZE[1] / 2.0];
+      CAMERA_SIZE = [aspect_ratio * BOX_SIZE[0] / 2.0, BOX_SIZE[1] / 2.0];
     } else if (DIMENSION == 3) {
       const fovy = 45.0 / 180.0 * Math.PI;
+      const max_box_size = Math.max(BOX_SIZE[0], BOX_SIZE[1], BOX_SIZE[2]);
       PERSPECTIVE = mat4.perspective(PERSPECTIVE, 
                                      fovy,            // Field of view.
                                      aspect_ratio,    // Aspect ratio.
-                                     BOX_SIZE / 10.0, // Near clip plane.
-                                     100 * BOX_SIZE); // Far clip plane.
-      VIEW_DISTANCE = 2 * BOX_SIZE;
+                                     max_box_size / 10.0, // Near clip plane.
+                                     100 * max_box_size); // Far clip plane.
+      VIEW_DISTANCE = 2 * max_box_size;
       make_look_at();
     } else {
       ERROR.innerHTML += 'ERROR: Invalid dimension specified: ' + DIMENSION + '.<br>';

--- a/jax_md/colab_tools/visualization.html
+++ b/jax_md/colab_tools/visualization.html
@@ -129,7 +129,7 @@
   function simulation_info_string() {
     return ('<p style="color:yellow">' +
             'Simulation Info:</p><div style="padding-left: 20px; padding-bottom: 10px;">' +
-            'Box Size:    ' + BOX_SIZE + '<br>' +
+            'Box Size:    ' + BOX_SIZE.map(x => parseFloat(x).toFixed(2)) + '<br>' +
             'Dimension:   ' + DIMENSION + '<br>' +
             'Frame Count: ' + FRAME_COUNT + '<br></div>');
   }


### PR DESCRIPTION
This PR adds a utility to visualize JAX MD simulations inside IPython notebooks. The new functionality is added inside `jax_md.colab_tools.renderer`. To use this functionality, inside a colaboratory notebook write code of the form,

```python
from jax_md.colab_tools import renderer

# Do simulation here.

# A scene is a dictionary of geometry objects.
# Here trajectory is a (timesteps, particle_count, 3) array.
scene = { 'particles': Sphere(trajectory) }
renderer.render(box_size, scene)
```