### PR TITLE
Fixed bug when Behler-Parrinello network functions were jit.

### DIFF
--- a/tests/energy_test.py
+++ b/tests/energy_test.py
@@ -475,18 +475,42 @@ class EnergyTest(jtu.JaxTestCase):
   def test_behler_parrinello_network(self, N_types, dtype):
     key = random.PRNGKey(1)
     R = np.array([[0,0,0], [1,1,1], [1,1,0]], dtype)
-    species = np.array([1, 1, N_types])
+    species = np.array([1, 1, N_types]) if N_types > 1 else None
     box_size = f32(1.5)
     displacement, _ = space.periodic(box_size)
     nn_init, nn_apply = energy.behler_parrinello(displacement, species)
     params = nn_init(key, R)
     nn_force_fn = grad(nn_apply, argnums=1)
-    nn_force = nn_force_fn(params, R)
-    nn_energy = nn_apply(params, R)
+    nn_force = jit(nn_force_fn)(params, R)
+    nn_energy = jit(nn_apply)(params, R)
     self.assertAllClose(np.any(np.isnan(nn_energy)), False)
     self.assertAllClose(np.any(np.isnan(nn_force)), False)
     self.assertAllClose(nn_force.shape, [3,3])
-  
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {
+          'testcase_name': '_N_types={}_dtype={}'.format(N_types, dtype.__name__),
+          'N_types': N_types,
+          'dtype': dtype,
+      } for N_types in N_TYPES_TO_TEST for dtype in POSITION_DTYPE))
+  def test_behler_parrinello_network_neighbor_list(self, N_types, dtype):
+    key = random.PRNGKey(1)
+    R = np.array([[0,0,0], [1,1,1], [1,1,0]], dtype)
+    species = np.array([1, 1, N_types]) if N_types > 1 else None
+    box_size = f32(1.5)
+    displacement, _ = space.periodic(box_size)
+    neighbor_fn, nn_init, nn_apply = energy.behler_parrinello_neighbor_list(
+      displacement, box_size, species)
+
+    nbrs = neighbor_fn(R) 
+    params = nn_init(key, R, nbrs)
+    nn_force_fn = grad(nn_apply, argnums=1)
+    nn_force = jit(nn_force_fn)(params, R, nbrs)
+    nn_energy = jit(nn_apply)(params, R, nbrs)
+    self.assertAllClose(np.any(np.isnan(nn_energy)), False)
+    self.assertAllClose(np.any(np.isnan(nn_force)), False)
+    self.assertAllClose(nn_force.shape, [3,3])
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {
           'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),


### PR DESCRIPTION
Fixes JAX issue #4881.

Also, fixes the case where `species=None` is passed to BP symmetry functions.