### PR TITLE
Introduce triplet function for three-body interactions and associated tests.

### DIFF
--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -516,16 +516,7 @@ def triplet(
     threaded through the metric.
   """
   def extract_parameters_by_dim(kwargs, dim: Union[int, List[int]] = 0):
-    """Helper function that extract parameters from a dictionary via dimension.
-
-    Args:
-      kwargs: dictionary where values are all ndarrays
-      dim: dimension of parameters to extract
-
-    Returns:
-      A dictionary with the extracted elements of kwargs of the correct
-      dimension.
-    """
+    """Helper function that extract parameters from a dictionary via dimension."""
     if isinstance(dim, int):
       dim = [dim]
     return {name: value for name, value in kwargs.items() if value.ndim in dim}

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -545,8 +545,8 @@ def triplet(fn: Callable[..., Array],
       _kwargs = merge_dicts(kwargs, dynamic_kwargs)
 
       mapped_args = extract_parameters_by_dim(_kwargs, [1, 3])
-      mapped_args = {arg_name: jnp.take(
-          arg_value, species, axis=0) for arg_name, arg_value in mapped_args.items()}
+      mapped_args = {arg_name: arg_value[species]
+          for arg_name, arg_value in mapped_args.items()}
       # While we support 2 dimensional inputs, these often make less sense
       # as the parameters do not depend on the central atom
       unmapped_args = extract_parameters_by_dim(_kwargs, [0, 2])

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -544,12 +544,15 @@ def triplet(fn: Callable[..., Array],
 
       _kwargs = merge_dicts(kwargs, dynamic_kwargs)
 
-      mapped_args = extract_parameters_by_dim(_kwargs, [1, 3])
+      mapped_args = extract_parameters_by_dim(_kwargs, [3])
       mapped_args = {arg_name: arg_value[species]
           for arg_name, arg_value in mapped_args.items()}
       # While we support 2 dimensional inputs, these often make less sense
       # as the parameters do not depend on the central atom
-      unmapped_args = extract_parameters_by_dim(_kwargs, [0, 2])
+      unmapped_args = extract_parameters_by_dim(_kwargs, [0])
+
+      if extract_parameters_by_dim(_kwargs, [1, 2]):
+        assert ValueError('Improper argument dimensions (1 or 2) not well defined for triplets.')
 
       def compute_triplet(dR, mapped_args, unmapped_args):
         paired_args = extract_parameters_by_dim(mapped_args, 2)

--- a/tests/smap_test.py
+++ b/tests/smap_test.py
@@ -790,7 +790,7 @@ class SMapTest(jtu.JaxTestCase):
       square = lambda dR, param: param * np.sum(np.square(dR))
       params = f32(np.array([[[1., 1.], [2., 0.]], [[0., 2.], [1., 1.]]]))
 
-      count = PARTICLE_COUNT // 250
+      count = PARTICLE_COUNT // 50
       key, split = random.split(key)
       species = random.randint(split, (count,), 0, 2)
       displacement, _ = space.free()


### PR DESCRIPTION
Introduce a triplet function in smap (extension of pair) that enables functions that operate on three-body interactions (two displacements or distances) to operate on an entire system.

Design decision:
1) Flexibility of parameters sharing ensures that all appropriate parameters are passed to the three body interaction term. Parameters of size 0 and 2 are passed in directly (although the latter has less physical meaning). Parameters of size 1 and 3 are assumed to be defined by the central atom and vmapped over.

2) Maintain a division by 2. after the high precision sum as most three body interaction terms will be symmetric.