### PR TITLE
fix bug in calculate_bond_data function

### DIFF
--- a/notebooks/customizing_potentials_cookbook.ipynb
+++ b/notebooks/customizing_potentials_cookbook.ipynb
@@ -80,7 +80,7 @@
         "  metric = space.map_product(space.canonicalize_displacement_or_metric(displacement))\n",
         "  dr = metric(R,R)\n",
         "\n",
-        "  dr_include = np.triu(np.where(dr<1, 1, 0)) - np.eye(R.shape[0],dtype=np.int32)\n",
+        "  dr_include = np.triu(np.where(dr<dr_cutoff, 1, 0)) - np.eye(R.shape[0],dtype=np.int32)\n",
         "  index_list=np.dstack(np.meshgrid(np.arange(N), np.arange(N), indexing='ij'))\n",
         "\n",
         "  i_s = np.where(dr_include==1, index_list[:,:,0], -1).flatten()\n",


### PR DESCRIPTION
previous version used a dr_cutoff of 1 regardless of what was passed.

Thanks to @MaxiLechner for pointing this out!