### PR TITLE
Added call to canonicalize_mass in npt_nose_hoover

### DIFF
--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -652,7 +652,8 @@ def npt_nose_hoover(energy_fn: Callable[..., Array],
     N, dim = R.shape
 
     _kT = kT if 'kT' not in kwargs else kwargs['kT']
-
+    
+    mass = quantity.canonicalize_mass(mass)
     V = jnp.sqrt(_kT / mass) * random.normal(key, R.shape, dtype=R.dtype)
     V = V - jnp.mean(V, axis=0, keepdims=True)
     KE = quantity.kinetic_energy(V, mass)


### PR DESCRIPTION
I notice that there is an inconsistence in the handling of the mass argumento of the init_fn for the npt_nose_hoover simulations. While for the other simulation functions the masses are run through the canonicalize_mass function that call is missing for the npt_nose_hoover. This results in an inconsistence where one can use "row" vectors fr the masses in the other simulation functions but not in the npt_nose_hoover.

The fix consists of adding the very same call to canonicalize_mass that is present in the other simulation functions.