### PR TITLE
Set initial configuration to have null total momentum 

### DIFF
--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -171,7 +171,7 @@ def nve(energy_or_force_fn: Callable[..., Array],
   def init_fn(key, R, kT, mass=f32(1.0), **kwargs):
     mass = quantity.canonicalize_mass(mass)
     V = jnp.sqrt(kT / mass) * random.normal(key, R.shape, dtype=R.dtype)
-    V = V - jnp.mean(V*mass, axis=0, keepdims=True)/mass
+    V = V - jnp.mean(V * mass, axis=0, keepdims=True) / mass
     return NVEState(R, V, force_fn(R, **kwargs), mass)  # pytype: disable=wrong-arg-count
 
   def step_fn(state, **kwargs):
@@ -468,7 +468,7 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
 
     mass = quantity.canonicalize_mass(mass)
     V = jnp.sqrt(_kT / mass) * random.normal(key, R.shape, dtype=R.dtype)
-    V = V - jnp.mean(V*mass, axis=0, keepdims=True)/mass
+    V = V - jnp.mean(V * mass, axis=0, keepdims=True) / mass
     KE = quantity.kinetic_energy(V, mass)
 
     return NVTNoseHooverState(R, V, force_fn(R, **kwargs), mass,
@@ -655,7 +655,7 @@ def npt_nose_hoover(energy_fn: Callable[..., Array],
     
     mass = quantity.canonicalize_mass(mass)
     V = jnp.sqrt(_kT / mass) * random.normal(key, R.shape, dtype=R.dtype)
-    V = V - jnp.mean(V*mass, axis=0, keepdims=True)/mass
+    V = V - jnp.mean(V * mass, axis=0, keepdims=True) / mass
     KE = quantity.kinetic_energy(V, mass)
 
     # The box position is defined via pos = (1 / d) log V / V_0.


### PR DESCRIPTION
In the current version of jax-md, the functions that generate the initial state for the _nve_, _nvt_nose_hoover_ and _npt_nose_hoover_ are initialised into states with zero total velocity instead if states with zero total momentum. This is not, in my experience with MD, the expected result of an initial state should have null total momentum, as it is one of the conserved magnitudes of the system. Having non-zero total momentum leads wrong calculations of the temperature and complicates the analysis o the resulting trajectory.

I didn't change the behaviour of _nvt_langevin_ as it clearly states that the option is center_velocities and I am not used to these kind of simulations. However, it may present the same errors in the temperature calculation than the other collectives. 