### PR TITLE
use int32 for neighbor lists and cell indexes.

### DIFF
--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -683,11 +683,11 @@ def neighbor_list(displacement_or_metric: DisplacementOrMetricFn,
     dR = d(position, neigh_position)
 
     mask = (dR < cutoff_sq) & (idx < N)
-    out_idx = N * jnp.ones(idx.shape, jnp.int32)
+    out_idx = N * jnp.ones(idx.shape, i32)
 
-    cumsum = jnp.cumsum(mask, axis=1, dtype=i32)
+    cumsum = jnp.cumsum(mask, axis=1)
     index = jnp.where(mask, cumsum - 1, idx.shape[1] - 1)
-    p_index = jnp.arange(idx.shape[0], dtype=i32)[:, None]
+    p_index = jnp.arange(idx.shape[0])[:, None]
     out_idx = out_idx.at[p_index, index].set(idx)
     max_occupancy = jnp.max(cumsum[:, -1])
 

--- a/tests/partition_test.py
+++ b/tests/partition_test.py
@@ -24,7 +24,6 @@ from jax.config import config as jax_config
 from jax import random
 import jax.numpy as np
 from jax import ops
-from jax import make_jaxpr
 
 from jax import grad
 

--- a/tests/partition_test.py
+++ b/tests/partition_test.py
@@ -69,6 +69,7 @@ class CellListTest(jtu.JaxTestCase):
     cell_fn = partition.cell_list(box_size, cell_size)
 
     cell_list = cell_fn.allocate(R)
+    self.assertEqual(cell_list.id_buffer.dtype, jnp.int32)
 
     self.assertAllClose(R[0], cell_list.position_buffer[0, 0, 0])
     self.assertAllClose(R[1], cell_list.position_buffer[1, 8, 1])

--- a/tests/partition_test.py
+++ b/tests/partition_test.py
@@ -347,6 +347,7 @@ class NeighborListTest(jtu.JaxTestCase):
     ]
     )
     neighbors = neighbor_list_fn.allocate(R)
+    self.assertEqual(neighbors.idx.dtype, jnp.int32)
 
     # two first point are close to eachother
     R = jnp.array(
@@ -360,15 +361,7 @@ class NeighborListTest(jtu.JaxTestCase):
 
     neighbors = neighbors.update(R)
     self.assertTrue(neighbors.did_buffer_overflow)
-
-    # Ensure that updating the neighbor matrix doesn't use i64 matrices
-    expr = make_jaxpr(neighbors.update)(R)
-    i64_neighbor_matrix = "i64[4,9]" in str(expr)
-    if i64_neighbor_matrix:
-      print(str(expr))
-    assert i64_neighbor_matrix == False, "Construction of the neighbor matrix creates large i64 matrices"
-
-
+    self.assertEqual(neighbors.idx.dtype, jnp.int32)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes #159. 