### PR TITLE
Fix code blocks and equations in documentation

### DIFF
--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -17,22 +17,35 @@
   The elastic modulus tensor describes a material's response to different
   boundary deformations. Specifically, for a small deformation given by a
   symmetric strain tensor e, the change in energy is
-    U / V^0 = U^0/V^0 + s^0_{ij} e_{ji} + (1/2) C_{ijkl} e_{ij} e_{kl} + ...
-  where V^0 is the volume, U^0 is the initial energy, s^0 is the residual stress
-  tensor of the undeformed system, and C is the elastic modulus tensor. C is
+
+  .. math::
+
+     U / V^0 = U^0/V^0 + s^0_{ij} e_{ji} + (1/2) C_{ijkl} e_{ij} e_{kl} + \ldots{}
+  
+  where :math:`V^0` is the volume, :math:`U^0` is the initial energy, :math:`s^0` is the residual stress
+  tensor of the undeformed system, and :math:`C` is the elastic modulus tensor. :math:`C` is
   a fourth-rank tensor of shape (dimension,dimension,dimension,dimension), with
   the following symmetries.
 
     Minor symmetries:
-      C_ijkl = C_jikl = C_ijlk
+
+    .. math::
+
+       C_{ijkl} = C_{jikl} = C_{ijlk}
 
     Major symmetries:
-      C_ijkl = C_lkij
+
+    .. math::
+
+       C_{ijkl} = C_{lkij}
 
   The minor symmetries are also reflected in the symmetric nature
   of stress and strain tensors:
-    s_ij = s_ji
-    e_ij = e_ji
+
+  .. math::
+  
+     s_{ij} = s_{ji}
+     e_{ij} = e_{ji}
 
   In general, there are 21 independent elastic constants in 3 dimension (6 in 2
   dimensions). While systems with additional symmetries (e.g. isotropic,

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -569,26 +569,28 @@ def neighbor_list(displacement_or_metric: DisplacementOrMetricFn,
 
   Here is a typical example of a simulation loop with neighbor lists:
 
-  >>> init_fn, apply_fn = simulate.nve(energy_fn, shift, 1e-3)
-  >>> exact_init_fn, exact_apply_fn = simulate.nve(exact_energy_fn, shift, 1e-3)
-  >>>
-  >>> nbrs = neighbor_fn.allocate(R)
-  >>> state = init_fn(random.PRNGKey(0), R, neighbor_idx=nbrs.idx)
-  >>>
-  >>> def body_fn(i, state):
-  >>>   state, nbrs = state
-  >>>   nbrs = nbrs.update(state.position)
-  >>>   state = apply_fn(state, neighbor_idx=nbrs.idx)
-  >>>   return state, nbrs
-  >>>
-  >>> step = 0
-  >>> for _ in range(20):
-  >>>   new_state, nbrs = lax.fori_loop(0, 100, body_fn, (state, nbrs))
-  >>>   if nbrs.did_buffer_overflow:
-  >>>     nbrs = neighbor_fn.allocate(state.position)
-  >>>   else:
-  >>>     state = new_state
-  >>>     step += 1
+  .. code-block:: python
+
+     init_fn, apply_fn = simulate.nve(energy_fn, shift, 1e-3)
+     exact_init_fn, exact_apply_fn = simulate.nve(exact_energy_fn, shift, 1e-3)
+  
+     nbrs = neighbor_fn.allocate(R)
+     state = init_fn(random.PRNGKey(0), R, neighbor_idx=nbrs.idx)
+  
+     def body_fn(i, state):
+       state, nbrs = state
+       nbrs = nbrs.update(state.position)
+       state = apply_fn(state, neighbor_idx=nbrs.idx)
+       return state, nbrs
+  
+     step = 0
+     for _ in range(20):
+       new_state, nbrs = lax.fori_loop(0, 100, body_fn, (state, nbrs))
+       if nbrs.did_buffer_overflow:
+         nbrs = neighbor_fn.allocate(state.position)
+       else:
+         state = new_state
+         step += 1
 
   Args:
     displacement: A function `d(R_a, R_b)` that computes the displacement

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -232,9 +232,9 @@ def pair_correlation(displacement_or_metric: Union[DisplacementFn, MetricFn],
 
   The pair correlation function measures the number of particles at a given
   distance from a central particle. The pair correlation function is defined
-  by $g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.$ We make the
+  by :math:`g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.` We make the
   approximation
-  $\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}$.
+  :math:`\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}`.
 
   Args:
     displacement_or_metric: A function that computes the displacement or
@@ -296,9 +296,9 @@ def pair_correlation_neighbor_list(
 
   The pair correlation function measures the number of particles at a given
   distance from a central particle. The pair correlation function is defined
-  by $g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.$ We make the
+  by :math:`g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.` We make the
   approximation,
-  $\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}$.
+  :math:`\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}`.
 
   This function uses neighbor lists to speed up the calculation.
 

--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -252,9 +252,9 @@ def nose_hoover_chain(dt: float,
   timescale than the rest of the simulation. Therefore, it sometimes necessary
   to integrate the chain over several substeps for each step of MD. To do this
   we follow the Suzuki-Yoshida scheme. Specifically, we subdivide our chain
-  simulation into $n_c$ substeps. These substeps are further subdivided into
-  $n_sy$ steps. Each $n_sy$ step has length $\delta_i = \Delta t w_i / n_c$
-  where $w_i$ are constants such that $\sum_i w_i = 1$. See the table of
+  simulation into :math:`n_c` substeps. These substeps are further subdivided into
+  :math:`n_sy` steps. Each :math:`n_sy` step has length :math:`\delta_i = \Delta t w_i / n_c`
+  where :math:`w_i` are constants such that :math:`\sum_i w_i = 1`. See the table of
   Suzuki_Yoshida weights above for specific values. The number of substeps
   and the number of Suzuki-Yoshida steps are set using the `chain_steps` and
   `sy_steps` arguments.
@@ -274,7 +274,7 @@ def nose_hoover_chain(dt: float,
       simulation.
     chain_length: An integer specifying the number of particles in
       the Nose-Hoover chain.
-    chain_steps: An integer specifying the number, $n_c$, of outer substeps.
+    chain_steps: An integer specifying the number, :math:`n_c`, of outer substeps.
     sy_steps: An integer specifying the number of Suzuki-Yoshida steps. This
       must be either 1, 3, 5, or 7.
     tau: A floating point timescale over which temperature equilibration occurs.
@@ -433,7 +433,7 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
       should pass `kT` as a keyword argument to the step function.
     chain_length: An integer specifying the number of particles in
       the Nose-Hoover chain.
-    chain_steps: An integer specifying the number, $n_c$, of outer substeps.
+    chain_steps: An integer specifying the number, :math:`n_c`, of outer substeps.
     sy_steps: An integer specifying the number of Suzuki-Yoshida steps. This
       must be either 1, 3, 5, or 7.
     tau: A floating point timescale over which temperature equilibration occurs.

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -302,24 +302,25 @@ def periodic_general(box: Box,
 
 
   Example:
-  ```python
-    from jax import random
-    side_length = 10.0
-    disp_frac, shift_frac = periodic_general(side_length,
-                                             fractional_coordinates=True)
-    disp_real, shift_real = periodic_general(side_length,
-                                             fractional_coordinates=False)
+  
+  .. code-block:: python
 
-    # Instantiate random positions in both parameterizations.
-    R_frac = random.uniform(random.PRNGKey(0), (4, 3))
-    R_real = side_length * R_frac
+     from jax import random
+     side_length = 10.0
+     disp_frac, shift_frac = periodic_general(side_length,
+                                               fractional_coordinates=True)
+     disp_real, shift_real = periodic_general(side_length,
+                                               fractional_coordinates=False) 
 
-    # Make some shfit vectors.
-    dR = random.normal(random.PRNGKey(0), (4, 3))
+     # Instantiate random positions in both parameterizations.
+     R_frac = random.uniform(random.PRNGKey(0), (4, 3))
+     R_real = side_length * R_frac
 
-    disp_real(R_real[0], R_real[1]) == disp_frac(R_frac[0], R_frac[1])
-    transform(side_length, shift_frac(R_frac, 1.0)) == shift_real(R_real, 1.0)
-  ```
+     # Make some shfit vectors.
+     dR = random.normal(random.PRNGKey(0), (4, 3))
+
+     disp_real(R_real[0], R_real[1]) == disp_frac(R_frac[0], R_frac[1])
+     transform(side_length, shift_frac(R_frac, 1.0)) == shift_real(R_real, 1.0)
 
   It is often desirable to deform a simulation cell either: using a finite
   deformation during a simulation, or using an infinitesimal deformation while

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -265,40 +265,40 @@ def periodic_general(box: Box,
                      wrapped: bool=True) -> Space:
   """Periodic boundary conditions on a parallelepiped.
 
-  This function defines a simulation on a parallelepiped, $X$, formed by
-  applying an affine transformation, $T$, to the unit hypercube
-  $U = [0, 1]^d$ along with periodic boundary conditions across all
+  This function defines a simulation on a parallelepiped, :math:`X`, formed by
+  applying an affine transformation, :math:`T`, to the unit hypercube
+  :math:`U = [0, 1]^d` along with periodic boundary conditions across all
   of the faces.
 
-  Formally, the space is defined such that $X = {Tu : u \in [0, 1]^d}$.
+  Formally, the space is defined such that :math:`X = {Tu : u \in [0, 1]^d}`.
 
-  The affine transformation, $T$, can be specified in a number of different
-  ways. For a parallelepiped that is: 1) a cube of side length $L$, the affine
+  The affine transformation, :math:`T`, can be specified in a number of different
+  ways. For a parallelepiped that is: 1) a cube of side length :math:`L`, the affine
   transformation can simply be a scalar; 2) an orthorhombic unit cell can be
   specified by a vector `[Lx, Ly, Lz]` of lengths for each axis; 3) a general
   triclinic cell can be specified by an upper triangular matrix.
 
-  There are a number of ways to parameterize a simulation on $X$.
-  `periodic_general` supports two parametrizations of $X$ that can be selected
+  There are a number of ways to parameterize a simulation on :math:`X`.
+  `periodic_general` supports two parametrizations of :math:`X` that can be selected
   using the `fractional_coordinates` keyword argument.
     1) When `fractional_coordinates=True`, particle positions are stored in the
-       unit cube, $u\in U$. Here, the displacement function computes the
-       displacement between $x, y \in X$ as $d_X(x, y) = Td_U(u, v)$ where
-       $d_U$ is the displacement function on the unit cube, $U$, $x = Tu$, and
-       $v = Tv$ with $u, v\in U$. The derivative of the displacement function
-       is defined so that derivatives live in $X$ (as opposed to being
-       backpropagated to $U$). The shift function, `shift_fn(R, dR)` is defined
-       so that $R$ is expected to lie in $U$ while $dR$ should lie in $X$. This
+       unit cube, :math:`u\in U`. Here, the displacement function computes the
+       displacement between :math:`x, y \in X` as :math:`d_X(x, y) = Td_U(u, v)` where
+       :math:`d_U` is the displacement function on the unit cube, :math:`U`, :math:`x = Tu`, and
+       :math:`v = Tv` with :math:`u, v \in U`. The derivative of the displacement function
+       is defined so that derivatives live in :math:`X` (as opposed to being
+       backpropagated to :math:`U`). The shift function, `shift_fn(R, dR)` is defined
+       so that :math:`R` is expected to lie in :math:`U` while :math:`dR` should lie in :math:`X`. This
        combination enables code such as `shift_fn(R, force_fn(R))` to work as
        intended.
 
     2) When `fractional_coordinates=False`, particle positions are stored in
-       the parallelepiped $X$. Here, for $x, y\in X$, the displacement function
-       is defined as $d_X(x, y) = Td_U(T^{-1}x, T^{-1}y)$. Since there is an
-       extra multiplication by $T^{-1}$, this parameterization is typically
+       the parallelepiped :math:`X`. Here, for :math:`x, y \in X`, the displacement function
+       is defined as :math:`d_X(x, y) = Td_U(T^{-1}x, T^{-1}y)`. Since there is an
+       extra multiplication by :math:`T^{-1}`, this parameterization is typically
        slower than `fractional_coordinates=False`. As in 1), the displacement
-       function is defined to compute derivatives in $X$. The shift function
-       is defined so that $R$ and $dR$ should both lie in $X$.
+       function is defined to compute derivatives in :math:`X`. The shift function
+       is defined so that :math:`R` and :math:`dR` should both lie in :math:`X`.
 
 
   Example:
@@ -326,9 +326,9 @@ def periodic_general(box: Box,
   deformation during a simulation, or using an infinitesimal deformation while
   computing elastic constants. To do this using fractional coordinates, we can
   supply a new affine transformation as `displacement_fn(Ra, Rb, box=new_box)`.
-  When using real coordinates, we can specify positions in a space $X$ defined
-  by an affine transformation $T$ and compute displacements in a deformed space
-  $X'$ defined by an affine transformation $T'$. This is done by writing
+  When using real coordinates, we can specify positions in a space :math:`X` defined
+  by an affine transformation :math:`T` and compute displacements in a deformed space
+  :math:`X'` defined by an affine transformation :math:`T'`. This is done by writing
   `displacement_fn(Ra, Rb, new_box=new_box)`.
 
   There are a few caveats when using `periodic_general`. `periodic_general`

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -316,7 +316,7 @@ def periodic_general(box: Box,
      R_frac = random.uniform(random.PRNGKey(0), (4, 3))
      R_real = side_length * R_frac
 
-     # Make some shfit vectors.
+     # Make some shift vectors.
      dR = random.normal(random.PRNGKey(0), (4, 3))
 
      disp_real(R_real[0], R_real[1]) == disp_frac(R_frac[0], R_frac[1])


### PR DESCRIPTION
This PR adds reStructuredText Python code blocks `.. code-block:: python` to correctly render the documentation

### This PR:
<img width="720" alt="Screenshot 2022-04-14 at 16 16 10" src="https://user-images.githubusercontent.com/20258504/163409940-94044294-fcbd-47c8-a762-a6461390d945.png">
<img width="720" alt="Screenshot 2022-04-14 at 16 16 19" src="https://user-images.githubusercontent.com/20258504/163409961-e4fd62c4-8a4d-40fc-8c89-8f70a5b2c324.png">

### Previously:
<img width="720" alt="Screenshot 2022-04-14 at 16 16 51" src="https://user-images.githubusercontent.com/20258504/163409980-b0cbfaf5-2aae-497d-adb8-0feb32a75cf0.png">
<img width="720" alt="Screenshot 2022-04-14 at 16 16 58" src="https://user-images.githubusercontent.com/20258504/163409989-fbc30dcb-f883-43ac-bf7c-d3ed4309e87c.png">
