### PR TITLE
Fix docstring formatting

### DIFF
--- a/docs/jax_md.energy.rst
+++ b/docs/jax_md.energy.rst
@@ -30,7 +30,6 @@ Classical Potentials
 .. autofunction:: bks_pair
 .. autofunction:: bks_neighbor_list
 
-.. autofunction:: bks_silica
 .. autofunction:: bks_silica_pair
 .. autofunction:: bks_silica_neighbor_list
 

--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -193,7 +193,7 @@ def athermal_moduli(energy_fn: Callable[..., Array],
       function must take as an argument `perturbation` which perturbs the
       box shape. Any energy function constructed using `smap` or in `energy.py`
       with a standard space will satisfy this property.
-    tether_strength: scalar. Strength of the "tether" applied to each particle,
+    tether_strength: Scalar. Strength of the "tether" applied to each particle,
       which can be necessary to make the Hessian matrix non-singular. Solving
       for the non-affine response of each particle requires that the Hessian is
       positive definite. However, there can often be zero modes (eigenvectors of
@@ -201,24 +201,23 @@ def athermal_moduli(energy_fn: Callable[..., Array],
       therefore do not affect the elastic constants despite the zero eigenvalue.
       The most common example is the global translational modes. To solve for
       the non-affine response, we consider the "tethered Hessian"
-        H + tether_strength * I,
-      where I is the identity matrix and tether_strength is a small constant.
-    gradient_check: None or scalar. If not None, a check will be performed
+      `H + tether_strength * I`, 
+      where `I` is the identity matrix and `tether_strength` is a small constant.
+    gradient_check: `None` or scalar. If not `None`, a check will be performed
       to guarantee that the maximum component of the gradient is less than
-      gradient_check. In other words, that
-        jnp.amax(jnp.abs(grad(energy_fn)(R, box=box))) < gradient_check == True
+      `gradient_check`. In other words, that
+      `jnp.amax(jnp.abs(grad(energy_fn)(R, box=box))) < gradient_check == True`
       NOTE: JAX currently does not support proper runtime error handling.
       Therefore, if this check fails, the calculation will return an array
-      of jnp.nan's. It is the users responsibility, if they want to use this
+      of `jnp.nan`'s. It is the users responsibility, if they want to use this
       check, to then ensure that the returned array is not full of nans.
     cg_tol: scalar. Tolerance used when solving for the non-affine response.
-    check_convergence: bool. If true, calculate_EMT will return a boolean
+    check_convergence: bool. If true, `calculate_EMT` will return a boolean
       flag specifying if the cg solve routine converged to the desired
-      tolerance. The default is False, but convergence checking is highly
+      tolerance. The default is `False`, but convergence checking is highly
       recommended especially when using 32-bit precision data.
 
   Return: A function to calculate the elastic modulus tensor
-
   """
 
   def calculate_emt(R: Array,
@@ -226,7 +225,7 @@ def athermal_moduli(energy_fn: Callable[..., Array],
                     **kwargs) -> Array:
     """Calculate the elastic modulus tensor.
 
-    energy_fn(R) corresponds to the state around which we are expanding
+    `energy_fn(R)` corresponds to the state around which we are expanding
 
     Args:
       R: array of shape `[N,dimension]` of particle positions. This does not

--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -567,7 +567,6 @@ def extract_isotropic_moduli(C: Array) -> Dict:
       satisfy both the major and minor symmetries, but this is not checked.
 
   Return: a dictionary containing the elastic constants.
-
   """
   if C.shape[0] == 2:
     cxxxx,cyyyy,cxyxy,cxxyy,cxxxy,cyyxy = _extract_elements(C,False)

--- a/jax_md/elasticity.py
+++ b/jax_md/elasticity.py
@@ -229,16 +229,15 @@ def athermal_moduli(energy_fn: Callable[..., Array],
     energy_fn(R) corresponds to the state around which we are expanding
 
     Args:
-      R: array of shape (N,dimension) of particle positions. This does not
+      R: array of shape `[N,dimension]` of particle positions. This does not
         generalize to arbitrary dimensions and is only implemented for
-          dimension == 2
-          dimension == 3
+        `dimension == 2` and `dimension == 3`.
       box: A box specifying the shape of the simulation volume. Used to infer
         the volume of the unit cell.
 
     Return: C or the tuple (C,converged)
-      where C is the Elastic modulus tensor as an array of shape (dimension,
-      dimension,dimension,dimension) that respects the major and minor
+      where C is the Elastic modulus tensor as an array of shape `[dimension,
+      dimension,dimension,dimension]` that respects the major and minor
       symmetries, and converged is a boolean flag (see above).
 
     """

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -88,7 +88,9 @@ def soft_sphere(dr: Array,
                 epsilon: Array=1,
                 alpha: Array=2,
                 **unused_kwargs) -> Array:
-  """Finite ranged repulsive interaction between soft spheres.
+  """.. _soft-sphere:
+  
+  Finite ranged repulsive interaction between soft spheres.
 
   Args:
     dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
@@ -118,7 +120,7 @@ def soft_sphere_pair(displacement_or_metric: DisplacementOrMetricFn,
                      epsilon: Array=1.0,
                      alpha: Array=2.0,
                      per_particle: bool=False) -> Callable[[Array], Array]:
-  """Convenience wrapper to compute soft sphere energy over a system."""
+  """Convenience wrapper to compute :ref:`soft sphere energy <soft-sphere>` over a system."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   alpha = maybe_downcast(alpha)
@@ -146,7 +148,7 @@ def soft_sphere_neighbor_list(
     format: NeighborListFormat=partition.OrderedSparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute soft spheres using a neighbor list."""
+  """Convenience wrapper to compute :ref:`soft spheres <soft-sphere>` using a neighbor list."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   alpha = maybe_downcast(alpha)
@@ -178,7 +180,9 @@ def lennard_jones(dr: Array,
                   sigma: Array=1,
                   epsilon: Array=1,
                   **unused_kwargs) -> Array:
-  """Lennard-Jones interaction between particles with a minimum at sigma.
+  """.. _lj-pot:
+  
+  Lennard-Jones interaction between particles with a minimum at `sigma`.
 
   Args:
     dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
@@ -206,7 +210,7 @@ def lennard_jones_pair(displacement_or_metric: DisplacementOrMetricFn,
                        r_onset: Array=2.0,
                        r_cutoff: Array=2.5,
                        per_particle: bool=False) -> Callable[[Array], Array]:
-  """Convenience wrapper to compute Lennard-Jones energy over a system."""
+  """Convenience wrapper to compute :ref:`Lennard-Jones energy <lj-pot>` over a system."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   r_onset = maybe_downcast(r_onset) * jnp.max(sigma)
@@ -236,7 +240,7 @@ def lennard_jones_neighbor_list(
     format: partition.NeighborListFormat=partition.OrderedSparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute Lennard-Jones using a neighbor list."""
+  """Convenience wrapper to compute :ref:`Lennard-Jones <lj-pot>` using a neighbor list."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   r_onset = maybe_downcast(r_onset) * jnp.max(sigma)
@@ -268,7 +272,10 @@ def morse(dr: Array,
           epsilon: Array=5.0,
           alpha: Array=5.0,
           **unused_kwargs) -> Array:
-  """Morse interaction between particles with a minimum at r0.
+  """.. _morse-pot:
+  
+  Morse interaction between particles with a minimum at `sigma`.
+
   Args:
     dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
     sigma: Distance between particles where the energy has a minimum. Should
@@ -294,7 +301,7 @@ def morse_pair(displacement_or_metric: DisplacementOrMetricFn,
                r_onset: float=2.0,
                r_cutoff: float=2.5,
                per_particle: bool=False) -> Callable[[Array], Array]:
-  """Convenience wrapper to compute Morse energy over a system."""
+  """Convenience wrapper to compute :ref:`Morse energy <morse-pot>` over a system."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   alpha = maybe_downcast(alpha)
@@ -324,7 +331,7 @@ def morse_neighbor_list(
     format: partition.NeighborListFormat=partition.OrderedSparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute Morse using a neighbor list."""
+  """Convenience wrapper to compute :ref:`Morse <morse-pot>` using a neighbor list."""
   sigma = maybe_downcast(sigma)
   epsilon = maybe_downcast(epsilon)
   alpha = maybe_downcast(alpha)
@@ -553,7 +560,7 @@ def bks_pair(displacement_or_metric: DisplacementOrMetricFn,
              repulsive_coeff: Array,
              coulomb_alpha: Array,
              cutoff: float) -> Callable[[Array], Array]:
-  """Convenience wrapper to compute BKS energy over a system."""
+  """Convenience wrapper to compute :ref:`BKS energy <bks-pot>` over a system."""
   Q_sq = maybe_downcast(Q_sq)
   exp_coeff = maybe_downcast(exp_coeff)
   exp_decay = maybe_downcast(exp_decay)
@@ -588,7 +595,7 @@ def bks_neighbor_list(
     format: partition.NeighborListFormat=partition.OrderedSparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute BKS energy using a neighbor list."""
+  """Convenience wrapper to compute :ref:`BKS energy <bks-pot>` using a neighbor list."""
   Q_sq = maybe_downcast(Q_sq)
   exp_coeff = maybe_downcast(exp_coeff)
   exp_decay = maybe_downcast(exp_decay)
@@ -655,7 +662,7 @@ def _bks_silica_self(Q_sq: Array, alpha: Array, cutoff: float) -> Array:
 def bks_silica_pair(displacement_or_metric: DisplacementOrMetricFn,
                     species: Array,
                     cutoff: float=8.0):
-  """Convenience wrapper to compute BKS energy for SiO2."""
+  """Convenience wrapper to compute :ref:`BKS energy <bks-pot>` for SiO2."""
   bks_pair_fn = bks_pair(displacement_or_metric,
                          species,
                          cutoff=cutoff,
@@ -684,7 +691,7 @@ def bks_silica_neighbor_list(
     format: partition.NeighborListFormat=partition.OrderedSparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute BKS energy using neighbor lists."""
+  """Convenience wrapper to compute :ref:`BKS energy <bks-pot>` using neighbor lists."""
   kwargs = {**BKS_SILICA_DICT, **neighbor_kwargs}
   neighbor_fn, bks_pair_fn = bks_neighbor_list(
     displacement_or_metric,
@@ -974,7 +981,9 @@ def eam(displacement: DisplacementFn,
         embedding_fn: Callable[[Array], Array],
         pairwise_fn: Callable[[Array], Array],
         axis: Optional[Tuple[int, ...]]=None) -> Callable[[Array], Array]:
-  """Interatomic potential as approximated by embedded atom model (EAM).
+  """.. _eam-pot:
+  
+  Interatomic potential as approximated by embedded atom model (EAM).
 
   This code implements the EAM approximation to interactions between metallic
   atoms. In EAM, the potential energy of an atom is given by two terms: a
@@ -1038,7 +1047,7 @@ def eam(displacement: DisplacementFn,
 
 def eam_from_lammps_parameters(displacement: DisplacementFn,
                                f: TextIO) -> Callable[[Array], Array]:
-  """Convenience wrapper to compute EAM energy with LAMMPS parameters."""
+  """Convenience wrapper to compute :ref:`EAM energy <eam-pot>` with LAMMPS parameters."""
   return eam(displacement, *load_lammps_eam_parameters(f)[:-1])
 
 
@@ -1147,7 +1156,8 @@ def eam_from_lammps_parameters_neighbor_list(
     fractional_coordinates=True,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Convenience wrapper to compute EAM energy with parameters from LAMMPS."""
+  """Convenience wrapper to compute :ref:`EAM energy <eam-pot>` 
+  with parameters from LAMMPS using a neighbor list.."""
   return eam_neighbor_list(displacement,
                            box_size,
                            *load_lammps_eam_parameters(f),

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -361,18 +361,17 @@ def gupta_potential(displacement, p, q, r_0n, U_n, A, cutoff):
 
   Args:
     displacement: Function to compute displacement between two positions.
-    p: Gupta potential parameter of the repulsive term that was fitted for
-    bulk gold.
-    q: Gupta potential parameter of the attractive term that was fitted for
-    bulk gold.
-    r_0n: Parameter that determines the length scale of the potential. This
-    value was particularly fit for gold clusters of size 55 atoms.
-    U_n: Parameter that determines the energy scale, fit particularly for
-    gold clusters of size 55 atoms.
-    A: Parameter that was obtained using the cohesive energy of the fcc gold
-    metal.
-    cutoff: Pairwise interactions that are farther than the cutoff distance
-    will be ignored.
+    p: Gupta potential parameter of the repulsive term that was fitted for bulk gold.
+    q: Gupta potential parameter of the attractive term that was fitted for bulk gold.
+    r_0n: 
+      Parameter that determines the length scale of the potential. This
+      value was particularly fit for gold clusters of size 55 atoms.
+    U_n: 
+      Parameter that determines the energy scale, fit particularly for
+      gold clusters of size 55 atoms.
+    A: Parameter that was obtained using the cohesive energy of the fcc gold metal.
+    cutoff: 
+      Pairwise interactions that are farther than the cutoff distance will be ignored.
 
   Returns:
     A function that takes in positions of gold atoms (shape `[n, 3]` where `n` is
@@ -507,16 +506,16 @@ def bks(dr: Array,
   from Ref. [3]
 
   Args:
-    dr: An ndarray of shape [n, m] of pairwise distances between particles.
-    Q_sq: An ndarray of shape [n, m] of pairwise product of partial charges.
-    exp_coeff: An ndarray of shape [n, m] that sets the scale of the
-    exponential decay of the short-range interaction.
-    attractive_coeff: An ndarray of shape [n, m] for the coefficient of the
-    attractive 6th order term.
-    repulsive_coeff: An ndarray of shape [n, m] for the coefficient of the
-    repulsive 24th order term, to prevent the unphysical fusion of atoms.
+    dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
+    Q_sq: An ndarray of shape `[n, m]` of pairwise product of partial charges.
+    exp_coeff: An ndarray of shape `[n, m]` that sets the scale of the
+      exponential decay of the short-range interaction.
+    attractive_coeff: An ndarray of shape `[n, m]` for the coefficient of the
+      attractive 6th order term.
+    repulsive_coeff: An ndarray of shape `[n, m]` for the coefficient of the
+      repulsive 24th order term, to prevent the unphysical fusion of atoms.
     coulomb_alpha: Damping parameter for the approximation of the long-range
-    coulombic interactions (a scalar).
+      coulombic interactions (a scalar).
     cutoff: Cutoff distance for considering pairwise interactions.
     unused_kwargs: Allows extra data (e.g. time) to be passed to the energy.
 
@@ -775,14 +774,15 @@ def stillinger_weber(displacement: DisplacementFn,
     displacement: The displacement function for the space.
     sigma: A scalar that sets the distance scale between neighbors.
     A: A scalar that determines the scale of two-body term.
-    B: A scalar that determines the scale of the 1 / r^p term.
+    B: A scalar that determines the scale of the :math:`1 / r^p` term.
     lam: A scalar that determines the scale of the three-body term.
     epsilon: A scalar that sets the total energy scale.
     gamma: A scalar used to fit the angle interaction.
-    three_body_strength: A scalar that determines the relative strength
-    of the angular interaction. Default value is 1.0, which works well
-    for the diamond crystal and liquid phases. 1.5 and 2.0 have been used
-    to model amorphous silicon.
+    three_body_strength: 
+      A scalar that determines the relative strength
+      of the angular interaction. Default value is `1.0`, which works well
+      for the diamond crystal and liquid phases. `1.5` and `2.0` have been used
+      to model amorphous silicon.
   Returns:
     A function that computes the total energy.
 
@@ -903,31 +903,40 @@ def load_lammps_eam_parameters(file: TextIO) -> Tuple[Callable[[Array], Array],
 
   This function reads single-element EAM potential fit parameters from a file
   in DYNAMO funcl format. In summary, the file contains:
-  Line 1-3: comments,
-  Line 4: Number of elements and the element type,
-  Line 5: The number of charge values that the embedding energy is evaluated
-  on (num_drho), interval between the charge values (drho), the number of
-  distances the pairwise energy and the charge density is evaluated on (num_dr),
-  the interval between these distances (dr), and the cutoff distance (cutoff).
-  The lines that come after are the embedding function evaluated on num_drho
-  charge values, charge function evaluated at num_dr distance values, and
-  pairwise energy evaluated at num_dr distance values. Note that the pairwise
-  energy is multiplied by distance (in units of eV x Angstroms). For more
-  details of the DYNAMO file format, see:
+
+  * Line 1-3: Comments
+  * Line 4: Number of elements and the element type
+  * Line 5: The number of charge values that the embedding energy is evaluated
+    on (`num_drho`), interval between the charge values (`drho`), the number of
+    distances the pairwise energy and the charge density is evaluated on (`num_dr`),
+    the interval between these distances (`dr`), and the cutoff distance (`cutoff`).
+
+  The lines that come after are the embedding function evaluated on `num_drho`
+  charge values, charge function evaluated at `num_dr` distance values, and
+  pairwise energy evaluated at `num_dr` distance values. Note that the pairwise
+  energy is multiplied by distance (in units of eV x Angstroms). 
+  
+  For more details of the DYNAMO file format, see:
   https://sites.google.com/a/ncsu.edu/cjobrien/tutorials-and-guides/eam
+  
   Args:
     f: File handle for the EAM parameters text file.
 
   Returns:
-    charge_fn: A function that takes an ndarray of shape [n, m] of distances
+    A tuple containing three functions and a cutoff distance.
+    
+    charge_fn: 
+      A function that takes an ndarray of shape `[n, m]` of distances
       between particles and returns a matrix of charge contributions.
     embedding_fn: 
       Function that takes an ndarray of shape `[n]` of charges and
       returns an ndarray of shape `[n]` of the energy cost of embedding an atom
       into the charge.
-    pairwise_fn: A function that takes an ndarray of shape [n, m] of distances
-      and returns an ndarray of shape [n, m] of pairwise energies.
-    cutoff: Cutoff distance for the embedding_fn and pairwise_fn.
+    pairwise_fn: 
+      A function that takes an ndarray of shape `[n, m]` of distances
+      and returns an ndarray of shape `[n, m]` of pairwise energies.
+    cutoff: 
+      Cutoff distance for the `embedding_fn` and `pairwise_fn`.
   """
   raw_text = file.read().split('\n')
   if 'setfl' not in raw_text[0]:
@@ -962,33 +971,41 @@ def eam(displacement: DisplacementFn,
   atoms. In EAM, the potential energy of an atom is given by two terms: a
   pairwise energy and an embedding energy due to the interaction between the
   atom and background charge density. The EAM potential for a single atomic
-  species is often
-  determined by three functions:
-    1) Charge density contribution of an atom as a function of distance.
-    2) Energy of embedding an atom in the background charge density.
-    3) Pairwise energy.
+  species is often determined by three functions:
+
+  1) Charge density contribution of an atom as a function of distance.
+  2) Energy of embedding an atom in the background charge density.
+  3) Pairwise energy.
+
   These three functions are usually provided as spline fits, and we follow the
   implementation and spline fits given by [1]. Note that in current
   implementation, the three functions listed above can also be expressed by a
   any function with the correct signature, including neural networks.
 
   Args:
-    displacement: A function that produces an ndarray of shape [n, m,
-      spatial_dimension] of particle displacements from particle positions
-      specified as an ndarray of shape [n, spatial_dimension] and [m,
-      spatial_dimension] respectively.
-    charge_fn: A function that takes an ndarray of shape [n, m] of distances
+    displacement: A function that produces an ndarray of shape `[n, m,
+      spatial_dimension]` of particle displacements from particle positions
+      specified as an ndarray of shape `[n, spatial_dimension]` and `[m,
+      spatial_dimension]` respectively.
+    box_size: The size of the simulation box.
+    charge_fn: A function that takes an ndarray of shape `[n, m]` of distances
       between particles and returns a matrix of charge contributions.
     embedding_fn: Function that takes an ndarray of shape `[n]` of charges and
       returns an ndarray of shape `[n]` of the energy cost of embedding an atom
       into the charge.
-    pairwise_fn: A function that takes an ndarray of shape [n, m] of distances
-      and returns an ndarray of shape [n, m] of pairwise energies.
+    pairwise_fn: A function that takes an ndarray of shape `[n, m]` of distances
+      and returns an ndarray of shape `[n, m]` of pairwise energies.
+    cutoff: A float specifying the maximum interaction distance.
+    dr_threshold: A float specifying the halo in the neighbor list.
     axis: Specifies which axis the total energy should be summed over.
+    fractional_coordinates: A boolean specifying whether or not the coordinates
+      will be in the unit cube.
+    format: The format of the neighbor list.
 
   Returns:
-    A function that computes the EAM energy of a set of atoms with positions
-    given by an [n, spatial_dimension] ndarray.
+    A tuple containing a function to build the neighbor list and function that
+    computes the EAM energy of a set of atoms with positions given by an
+    `[n, spatial_dimension]` ndarray.
 
   [1] Y. Mishin, D. Farkas, M.J. Mehl, DA Papaconstantopoulos, "Interatomic
   potentials for monoatomic metals from experimental data and ab initio

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -57,7 +57,7 @@ def simple_spring(dr: Array,
   """Isotropic spring potential with a given rest length.
 
   We define `simple_spring` to be a generalized Hookean spring with
-  agreement when alpha = 2.
+  agreement when `alpha = 2`.
   """
   return epsilon / alpha * (dr - length) ** alpha
 
@@ -375,7 +375,7 @@ def gupta_potential(displacement, p, q, r_0n, U_n, A, cutoff):
     will be ignored.
 
   Returns:
-    A function that takes in positions of gold atoms (shape [n, 3] where n is
+    A function that takes in positions of gold atoms (shape `[n, 3]` where `n` is
     the number of atoms) and returns the total energy of the system in units
     of eV.
 
@@ -1280,7 +1280,7 @@ def graph_network(displacement_fn: DisplacementFn,
     r_cutoff: A floating point cutoff; Edges will be added to the graph
       for pairs of particles whose separation is smaller than the cutoff.
     nodes: None or an ndarray of shape `[N, node_dim]` specifying the state
-      of the nodes. If None this is set to the zeroes vector. Often, for a
+      of the nodes. If None this is set to the zeros vector. Often, for a
       system with multiple species, this could be the species id.
     n_recurrences: The number of steps of message passing in the graph network.
     mlp_sizes: A tuple specifying the layer-widths for the fully-connected

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -841,41 +841,8 @@ def stillinger_weber_neighbor_list(
     format: NeighborListFormat=partition.Dense,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Computes the Stillinger-Weber potential.
-
-  The Stillinger-Weber (SW) potential [1] which is commonly used to model
-  silicon and similar systems. This function uses the default SW parameters
-  from the original paper. The SW potential was originally proposed to
-  model diamond in the diamond crystal phase and the liquid phase, and is
-  known to give unphysical amorphous configurations [2, 3]. For this reason,
-  we provide a three_body_strength parameter. Changing this number to 1.5
-  or 2.0 has been know to produce more physical amorphous phase, preventing
-  most atoms from having more than four nearest neighbors. Note that this
-  function currently assumes nearest-image-convention.
-
-  Args:
-    displacement: The displacement function for the space.
-    sigma: A scalar that sets the distance scale between neighbors.
-    A: A scalar that determines the scale of two-body term.
-    B: A scalar that determines the scale of the 1 / r^p term.
-    lam: A scalar that determines the scale of the three-body term.
-    epsilon: A scalar that sets the total energy scale.
-    gamma: A scalar used to fit the angle interaction.
-    three_body_strength: A scalar that determines the relative strength
-    of the angular interaction. Default value is 1.0, which works well
-    for the diamond crystal and liquid phases. 1.5 and 2.0 have been used
-    to model amorphous silicon.
-  Returns:
-    A function that computes the total energy.
-
-  [1] Stillinger, Frank H., and Thomas A. Weber. "Computer simulation of
-  local order in condensed phases of silicon." Physical review B 31.8
-  (1985): 5262.
-  [2] Holender, J. M., and G. J. Morgan. "Generation of a large structure
-  (105 atoms) of amorphous Si using molecular dynamics." Journal of
-  Physics: Condensed Matter 3.38 (1991): 7241.
-  [3] Barkema, G. T., and Normand Mousseau. "Event-based relaxation of
-  continuous disordered systems." Physical review letters 77.21 (1996): 4358.
+  """Convenience wrapper to compute :ref:`Stillinger-Weber <sw-pot>` 
+  using a neighbor list.
   """
   two_body_fn = partial(_sw_radial_interaction, sigma, B, cutoff)
   three_body_fn = partial(_sw_angle_interaction, gamma, sigma, cutoff)
@@ -1064,51 +1031,7 @@ def eam_neighbor_list(
     format: partition.NeighborListFormat = partition.Sparse,
     **neighbor_kwargs
     ) -> Tuple[NeighborFn, Callable[[Array, NeighborList], Array]]:
-  """Interatomic potential as approximated by embedded atom model (EAM).
-
-  This code implements the EAM approximation to interactions between metallic
-  atoms. In EAM, the potential energy of an atom is given by two terms: a
-  pairwise energy and an embedding energy due to the interaction between the
-  atom and background charge density. The EAM potential for a single atomic
-  species is often
-  determined by three functions:
-    1) Charge density contribution of an atom as a function of distance.
-    2) Energy of embedding an atom in the background charge density.
-    3) Pairwise energy.
-  These three functions are usually provided as spline fits, and we follow the
-  implementation and spline fits given by [1]. Note that in current
-  implementation, the three functions listed above can also be expressed by a
-  any function with the correct signature, including neural networks.
-
-  Args:
-    displacement: A function that produces an ndarray of shape [n, m,
-      spatial_dimension] of particle displacements from particle positions
-      specified as an ndarray of shape [n, spatial_dimension] and [m,
-      spatial_dimension] respectively.
-    box_size: The size of the simulation box.
-    charge_fn: A function that takes an ndarray of shape [n, m] of distances
-      between particles and returns a matrix of charge contributions.
-    embedding_fn: Function that takes an ndarray of shape [n] of charges and
-      returns an ndarray of shape [n] of the energy cost of embedding an atom
-      into the charge.
-    pairwise_fn: A function that takes an ndarray of shape [n, m] of distances
-      and returns an ndarray of shape [n, m] of pairwise energies.
-    cutoff: A float specifying the maximum interaction distance.
-    dr_threshold: A float specifying the halo in the neighbor list.
-    axis: Specifies which axis the total energy should be summed over.
-    fractional_coordinates: A boolean specifying whether or not the coordinates
-      will be in the unit cube.
-    format: The format of the neighbor list.
-
-  Returns:
-    A tuple containing a function to build the neighbor list and function that
-    computes the EAM energy of a set of atoms with positions given by an
-    [n, spatial_dimension] ndarray.
-
-  [1] Y. Mishin, D. Farkas, M.J. Mehl, DA Papaconstantopoulos, "Interatomic
-  potentials for monoatomic metals from experimental data and ab initio
-  calculations." Physical Review B, 59 (1999)
-  """
+  """Convenience wrapper to compute :ref:`EAM <eam-pot>` using a neighbor list."""
   metric = space.canonicalize_displacement_or_metric(displacement_or_metric)
 
   neighbor_fn = partition.neighbor_list(displacement_or_metric,

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -91,16 +91,16 @@ def soft_sphere(dr: Array,
   """Finite ranged repulsive interaction between soft spheres.
 
   Args:
-    dr: An ndarray of shape [n, m] of pairwise distances between particles.
+    dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
     sigma: Particle diameter. Should either be a floating point scalar or an
-      ndarray whose shape is [n, m].
+      ndarray whose shape is `[n, m]`.
     epsilon: Interaction energy scale. Should either be a floating point scalar
-      or an ndarray whose shape is [n, m].
+      or an ndarray whose shape is `[n, m]`.
     alpha: Exponent specifying interaction stiffness. Should either be a float
-      point scalar or an ndarray whose shape is [n, m].
+      point scalar or an ndarray whose shape is `[n, m]`.
     unused_kwargs: Allows extra data (e.g. time) to be passed to the energy.
   Returns:
-    Matrix of energies whose shape is [n, m].
+    Matrix of energies whose shape is `[n, m]`.
   """
 
   dr = dr / sigma
@@ -181,14 +181,14 @@ def lennard_jones(dr: Array,
   """Lennard-Jones interaction between particles with a minimum at sigma.
 
   Args:
-    dr: An ndarray of shape [n, m] of pairwise distances between particles.
+    dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
     sigma: Distance between particles where the energy has a minimum. Should
-      either be a floating point scalar or an ndarray whose shape is [n, m].
+      either be a floating point scalar or an ndarray whose shape is `[n, m]`.
     epsilon: Interaction energy scale. Should either be a floating point scalar
-      or an ndarray whose shape is [n, m].
+      or an ndarray whose shape is `[n, m]`.
     unused_kwargs: Allows extra data (e.g. time) to be passed to the energy.
   Returns:
-    Matrix of energies of shape [n, m].
+    Matrix of energies of shape `[n, m]`.
   """
   idr = (sigma / dr)
   idr = idr * idr
@@ -270,16 +270,16 @@ def morse(dr: Array,
           **unused_kwargs) -> Array:
   """Morse interaction between particles with a minimum at r0.
   Args:
-    dr: An ndarray of shape [n, m] of pairwise distances between particles.
+    dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
     sigma: Distance between particles where the energy has a minimum. Should
-      either be a floating point scalar or an ndarray whose shape is [n, m].
+      either be a floating point scalar or an ndarray whose shape is `[n, m]`.
     epsilon: Interaction energy scale. Should either be a floating point scalar
-      or an ndarray whose shape is [n, m].
+      or an ndarray whose shape is `[n, m]`.
     alpha: Range parameter. Should either be a floating point scalar or an
-      ndarray whose shape is [n, m].
+      ndarray whose shape is `[n, m]`.
     unused_kwargs: Allows extra data (e.g. time) to be passed to the energy.
   Returns:
-    Matrix of energies of shape [n, m].
+    Matrix of energies of shape `[n, m]`.
   """
   U = epsilon * (f32(1) - jnp.exp(-alpha * (dr - sigma)))**f32(2) - epsilon
   # TODO(cpgoodri): ErrorChecking following lennard_jones
@@ -443,7 +443,7 @@ def multiplicative_isotropic_cutoff(fn: Callable[..., Array],
   Then f'(r) = S(r)f(r).
 
   Args:
-    fn: A function that takes an ndarray of distances of shape [n, m] as well
+    fn: A function that takes an ndarray of distances of shape `[n, m]` as well
       as varargs.
     r_onset: A float specifying the distance marking the onset of deformation.
     r_cutoff: A float specifying the cutoff distance.
@@ -521,7 +521,7 @@ def bks(dr: Array,
     unused_kwargs: Allows extra data (e.g. time) to be passed to the energy.
 
   Returns:
-    Matrix of energies of shape [n, m].
+    Matrix of energies of shape `[n, m]`.
 
   [1] Van Beest, B. W. H., Gert Jan Kramer, and R. A. Van Santen. "Force fields
   for silicas and aluminophosphates based on ab initio calculations." Physical
@@ -921,8 +921,9 @@ def load_lammps_eam_parameters(file: TextIO) -> Tuple[Callable[[Array], Array],
   Returns:
     charge_fn: A function that takes an ndarray of shape [n, m] of distances
       between particles and returns a matrix of charge contributions.
-    embedding_fn: Function that takes an ndarray of shape [n] of charges and
-      returns an ndarray of shape [n] of the energy cost of embedding an atom
+    embedding_fn: 
+      Function that takes an ndarray of shape `[n]` of charges and
+      returns an ndarray of shape `[n]` of the energy cost of embedding an atom
       into the charge.
     pairwise_fn: A function that takes an ndarray of shape [n, m] of distances
       and returns an ndarray of shape [n, m] of pairwise energies.
@@ -978,8 +979,8 @@ def eam(displacement: DisplacementFn,
       spatial_dimension] respectively.
     charge_fn: A function that takes an ndarray of shape [n, m] of distances
       between particles and returns a matrix of charge contributions.
-    embedding_fn: Function that takes an ndarray of shape [n] of charges and
-      returns an ndarray of shape [n] of the energy cost of embedding an atom
+    embedding_fn: Function that takes an ndarray of shape `[n]` of charges and
+      returns an ndarray of shape `[n]` of the energy cost of embedding an atom
       into the charge.
     pairwise_fn: A function that takes an ndarray of shape [n, m] of distances
       and returns an ndarray of shape [n, m] of pairwise energies.

--- a/jax_md/energy.py
+++ b/jax_md/energy.py
@@ -354,10 +354,12 @@ def morse_neighbor_list(
 
 
 def gupta_potential(displacement, p, q, r_0n, U_n, A, cutoff):
-  """Gupta potential with default parameters for Au_55 cluster. Gupta
-  potential was introduced by R. P. Gupta [1]. This potential uses parameters
-  that were fit for bulk gold by Jellinek [2]. This particular implementation
-  of the Gupta potential was introduced by Garzon and Posada-Amarillas [3].
+  """.. _gupta-pot:
+
+  Gupta potential with default parameters for Au_55 cluster. Gupta
+  potential was introduced by R. P. Gupta [#gupta]_. This potential uses parameters
+  that were fit for bulk gold by Jellinek [#jellinek]_. This particular implementation
+  of the Gupta potential was introduced by Garzon and Posada-Amarillas [#garzon]_.
 
   Args:
     displacement: Function to compute displacement between two positions.
@@ -378,10 +380,11 @@ def gupta_potential(displacement, p, q, r_0n, U_n, A, cutoff):
     the number of atoms) and returns the total energy of the system in units
     of eV.
 
-  [1] R.P. Gupta, Phys. Rev. B 23, 6265 (1981)
-  [2] J. Jellinek, in Metal-Ligand Interactions, edited by N. Russo and
-  D. R. Salahub (Kluwer Academic, Dordrecht, 1996), p. 325.
-  [3] I. L. Garzon, A. Posada-Amarillas, Phys. Rev. B 54, 16 (1996)
+  .. rubric:: References
+  .. [#gupta] R.P. Gupta, Phys. Rev. B 23, 6265 (1981)
+  .. [#jellinek] J. Jellinek, in Metal-Ligand Interactions, edited by N. Russo and
+    D. R. Salahub (Kluwer Academic, Dordrecht, 1996), p. 325.
+  .. [#garzon] I.L. Garzon, A. Posada-Amarillas, Phys. Rev. B 54, 16 (1996)
   """
   def _gupta_term1(r, p, r_0n, cutoff):
     """Repulsive term in Gupta potential."""
@@ -434,12 +437,12 @@ def multiplicative_isotropic_cutoff(fn: Callable[..., Array],
                                     r_cutoff: float) -> Callable[..., Array]:
   """Takes an isotropic function and constructs a truncated function.
 
-  Given a function f:R -> R, we construct a new function f':R -> R such that
-  f'(r) = f(r) for r < r_onset, f'(r) = 0 for r > r_cutoff, and f(r) is C^1
-  everywhere. To do this, we follow the approach outlined in HOOMD Blue [1]
-  (thanks to Carl Goodrich for the pointer). We construct a function S(r) such
-  that S(r) = 1 for r < r_onset, S(r) = 0 for r > r_cutoff, and S(r) is C^1.
-  Then f'(r) = S(r)f(r).
+  Given a function `f:R -> R`, we construct a new function `f':R -> R` such that
+  `f'(r) = f(r)` for `r < r_onset`, `f'(r) = 0` for `r > r_cutoff`, and `f(r)` is :math:`C^1`
+  everywhere. To do this, we follow the approach outlined in HOOMD Blue  [#hoomd]_
+  (thanks to Carl Goodrich for the pointer). We construct a function `S(r)` such
+  that `S(r) = 1` for `r < r_onset`, `S(r) = 0` for `r > r_cutoff`, and `S(r)` is :math:`C^1`.
+  Then `f'(r) = S(r)f(r)`.
 
   Args:
     fn: A function that takes an ndarray of distances of shape `[n, m]` as well
@@ -451,7 +454,8 @@ def multiplicative_isotropic_cutoff(fn: Callable[..., Array],
     A new function with the same signature as fn, with the properties outlined
     above.
 
-  [1] HOOMD Blue documentation. Accessed on 05/31/2019.
+  .. rubric:: References
+  .. [#hoomd] HOOMD Blue documentation. Accessed on 05/31/2019.
       https://hoomd-blue.readthedocs.io/en/stable/module-md-pair.html#hoomd.md.pair.pair
   """
 
@@ -500,10 +504,12 @@ def bks(dr: Array,
         coulomb_alpha: Array,
         cutoff: float,
         **unused_kwargs) -> Array:
-  """Beest-Kramer-van Santen (BKS) potential[1] which is commonly used to
+  """.. _bks-pot:
+  
+  Beest-Kramer-van Santen (BKS) potential [#bks]_ which is commonly used to
   model silicas. This function computes the interaction between two
-  given atoms within the Buckingham form[2], following the implementation
-  from Ref. [3]
+  given atoms within the Buckingham form [#carre]_ , following the implementation
+  from Liu et al. [#liu]_ .
 
   Args:
     dr: An ndarray of shape `[n, m]` of pairwise distances between particles.
@@ -522,14 +528,15 @@ def bks(dr: Array,
   Returns:
     Matrix of energies of shape `[n, m]`.
 
-  [1] Van Beest, B. W. H., Gert Jan Kramer, and R. A. Van Santen. "Force fields
-  for silicas and aluminophosphates based on ab initio calculations." Physical
-  Review Letters 64.16 (1990): 1955.
-  [2] Carré, Antoine, et al. "Developing empirical potentials from ab initio
-  simulations: The case of amorphous silica." Computational Materials Science
-  124 (2016): 323-334.
-  [3] Liu, Han, et al. "Machine learning Forcefield for silicate glasses."
-  arXiv preprint arXiv:1902.03486 (2019).
+  .. rubric:: References
+  .. [#bks] Van Beest, B. W. H., Gert Jan Kramer, and R. A. Van Santen. "Force fields
+    for silicas and aluminophosphates based on ab initio calculations." Physical
+    Review Letters 64.16 (1990): 1955.
+  .. [#carre] Carré, Antoine, et al. "Developing empirical potentials from ab initio
+    simulations: The case of amorphous silica." Computational Materials Science
+    124 (2016): 323-334.
+  .. [#liu] Liu, Han, et al. "Machine learning Forcefield for silicate glasses."
+    arXiv preprint arXiv:1902.03486 (2019).
   """
   energy = (dsf_coulomb(dr, Q_sq, coulomb_alpha, cutoff) + \
             exp_coeff * jnp.exp(-dr / exp_decay) + \
@@ -758,15 +765,17 @@ def stillinger_weber(displacement: DisplacementFn,
                      epsilon: float = 2.16826,
                      three_body_strength: float =1.0,
                      cutoff: float = 3.77118) -> Callable[[Array], Array]:
-  """Computes the Stillinger-Weber potential.
+  """.. _sw-pot:
 
-  The Stillinger-Weber (SW) potential [1] which is commonly used to model
+  Computes the Stillinger-Weber potential.
+
+  The Stillinger-Weber (SW) potential [#stillinger]_ which is commonly used to model
   silicon and similar systems. This function uses the default SW parameters
   from the original paper. The SW potential was originally proposed to
   model diamond in the diamond crystal phase and the liquid phase, and is
-  known to give unphysical amorphous configurations [2, 3]. For this reason,
-  we provide a three_body_strength parameter. Changing this number to 1.5
-  or 2.0 has been know to produce more physical amorphous phase, preventing
+  known to give unphysical amorphous configurations [#holender]_ [#barkema]_ . 
+  For this reason, we provide a `three_body_strength` parameter. Changing this number to `1.5`
+  or `2.0` has been know to produce more physical amorphous phase, preventing
   most atoms from having more than four nearest neighbors. Note that this
   function currently assumes nearest-image-convention.
 
@@ -786,14 +795,14 @@ def stillinger_weber(displacement: DisplacementFn,
   Returns:
     A function that computes the total energy.
 
-  [1] Stillinger, Frank H., and Thomas A. Weber. "Computer simulation of
-  local order in condensed phases of silicon." Physical review B 31.8
-  (1985): 5262.
-  [2] Holender, J. M., and G. J. Morgan. "Generation of a large structure
-  (105 atoms) of amorphous Si using molecular dynamics." Journal of
-  Physics: Condensed Matter 3.38 (1991): 7241.
-  [3] Barkema, G. T., and Normand Mousseau. "Event-based relaxation of
-  continuous disordered systems." Physical review letters 77.21 (1996): 4358.
+  .. rubric:: References
+  .. [#stillinger] Stillinger, Frank H., and Thomas A. Weber. "Computer simulation of
+    local order in condensed phases of silicon." Physical review B 31.8 (1985): 5262.
+  .. [#holender] Holender, J. M., and G. J. Morgan. "Generation of a large structure
+    (105 atoms) of amorphous Si using molecular dynamics." Journal of
+    Physics: Condensed Matter 3.38 (1991): 7241.
+  .. [#barkema] Barkema, G. T., and Normand Mousseau. "Event-based relaxation of
+    continuous disordered systems." Physical review letters 77.21 (1996): 4358.
   """
   two_body_fn = partial(_sw_radial_interaction, sigma, B, cutoff)
   three_body_fn = partial(_sw_angle_interaction, gamma, sigma, cutoff)
@@ -978,9 +987,10 @@ def eam(displacement: DisplacementFn,
   3) Pairwise energy.
 
   These three functions are usually provided as spline fits, and we follow the
-  implementation and spline fits given by [1]. Note that in current
-  implementation, the three functions listed above can also be expressed by a
-  any function with the correct signature, including neural networks.
+  implementation and spline fits given by Mishin et al. [#mishin]_
+  Note that in current implementation, the three functions listed above 
+  can also be expressed by a any function with the correct signature, 
+  including neural networks.
 
   Args:
     displacement: A function that produces an ndarray of shape `[n, m,
@@ -1006,10 +1016,11 @@ def eam(displacement: DisplacementFn,
     A tuple containing a function to build the neighbor list and function that
     computes the EAM energy of a set of atoms with positions given by an
     `[n, spatial_dimension]` ndarray.
-
-  [1] Y. Mishin, D. Farkas, M.J. Mehl, DA Papaconstantopoulos, "Interatomic
-  potentials for monoatomic metals from experimental data and ab initio
-  calculations." Physical Review B, 59 (1999)
+  
+  .. rubric:: References
+  .. [#mishin] Y. Mishin, D. Farkas, M.J. Mehl, DA Papaconstantopoulos, "Interatomic
+    potentials for monoatomic metals from experimental data and ab initio
+    calculations." Physical Review B, 59 (1999)
   """
   metric = space.map_product(space.metric(displacement))
 

--- a/jax_md/minimize.py
+++ b/jax_md/minimize.py
@@ -64,9 +64,9 @@ def gradient_descent(energy_or_force: Callable[..., Array],
     Args:
       energy_or_force: A function that produces either an energy or a force from
         a set of particle positions specified as an ndarray of shape
-        [n, spatial_dimension].
-      shift_fn: A function that displaces positions, R, by an amount dR. Both R
-        and dR should be ndarrays of shape [n, spatial_dimension].
+        `[n, spatial_dimension]`.
+      shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+        and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
       step_size: A floating point specifying the size of each step.
 
     Returns:
@@ -87,11 +87,11 @@ class FireDescentState:
 
   Attributes:
     position: The current position of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     velocity: The current velocity of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     force: The current force on particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     dt: A float specifying the current step size.
     alpha: A float specifying the current momentum.
     n_pos: The number of steps in the right direction, so far.
@@ -120,9 +120,9 @@ def fire_descent(energy_or_force: Callable[..., Array],
   Args:
     energy_or_force: A function that produces either an energy or a force from
       a set of particle positions specified as an ndarray of shape
-      [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     quant: Either a quantity.Energy or a quantity.Force specifying whether
       energy_or_force is an energy or force respectively.
     dt_start: The initial step size during minimization as a float.

--- a/jax_md/minimize.py
+++ b/jax_md/minimize.py
@@ -117,7 +117,7 @@ def fire_descent(energy_or_force: Callable[..., Array],
                  f_alpha: float=0.99) -> Minimizer[FireDescentState]:
   """Defines FIRE minimization.
 
-  This code implements the "Fast Inertial Relaxation Engine" from [1].
+  This code implements the "Fast Inertial Relaxation Engine" from Bitzek et al. [#bitzek]_
 
   Args:
     energy_or_force: A function that produces either an energy or a force from
@@ -140,7 +140,8 @@ def fire_descent(energy_or_force: Callable[..., Array],
   Returns:
     See above.
 
-  [1] Bitzek, Erik, Pekka Koskinen, Franz Gahler, Michael Moseler,
+  .. rubric:: References
+  .. [#bitzek] Bitzek, Erik, Pekka Koskinen, Franz Gahler, Michael Moseler,
       and Peter Gumbsch. "Structural relaxation made simple."
       Physical review letters 97, no. 17 (2006): 170201.
   """

--- a/jax_md/minimize.py
+++ b/jax_md/minimize.py
@@ -20,10 +20,12 @@
 
   Minimization code follows the same overall structure as optimizers in JAX.
   Optimizers return two functions:
-    init_fn: function that initializes the  state of an optimizer. Should take
-      positions as an ndarray of shape [n, output_dimension]. Returns a state
+    init_fn: 
+      Function that initializes the  state of an optimizer. Should take
+      positions as an ndarray of shape `[n, output_dimension]`. Returns a state
       which will be a namedtuple.
-    apply_fn: function that takes a state and produces a new state after one
+    apply_fn: 
+      Function that takes a state and produces a new state after one
       step of optimization.
 """
 
@@ -123,7 +125,7 @@ def fire_descent(energy_or_force: Callable[..., Array],
       `[n, spatial_dimension]`.
     shift_fn: A function that displaces positions `R`, by an amount `dR`. Both `R`
       and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
-    quant: Either a quantity.Energy or a quantity.Force specifying whether
+    quant: Either a quantity.Energy or a quantity. Force specifying whether
       energy_or_force is an energy or force respectively.
     dt_start: The initial step size during minimization as a float.
     dt_max: The maximum step size during minimization as a float.

--- a/jax_md/nn.py
+++ b/jax_md/nn.py
@@ -104,15 +104,15 @@ def radial_symmetry_functions(displacement_or_metric: DisplacementOrMetricFn,
     species: An `[N_atoms]` that contains the species of each particle.
     etas: List of radial symmetry function parameters that control the spatial
       extension.
-    cutoff_distance: Neighbors whose distance is larger than cutoff_distance do
+    cutoff_distance: Neighbors whose distance is larger than `cutoff_distance` do
       not contribute to each others symmetry functions. The contribution of a
       neighbor to the symmetry function and its derivative goes to zero at this
       distance.
 
   Returns:
     A function that computes the radial symmetry function from input `[N_atoms,
-    spatial_dimension]` and returns `[N_atoms, N_etas * N_types]` where N_etas
-    is the number of eta parameters, N_types is the number of types of
+    spatial_dimension]` and returns `[N_atoms, N_etas * N_types]` where `N_etas`
+    is the number of eta parameters, `N_types` is the number of types of
     particles in the system.
   """
   metric = space.canonicalize_displacement_or_metric(displacement_or_metric)
@@ -157,15 +157,15 @@ def radial_symmetry_functions_neighbor_list(
     species: An `[N_atoms]` that contains the species of each particle.
     etas: List of radial symmetry function parameters that control the spatial
       extension.
-    cutoff_distance: Neighbors whose distance is larger than cutoff_distance do
+    cutoff_distance: Neighbors whose distance is larger than `cutoff_distance` do
       not contribute to each others symmetry functions. The contribution of a
       neighbor to the symmetry function and its derivative goes to zero at this
       distance.
 
   Returns:
     A function that computes the radial symmetry function from input `[N_atoms,
-    spatial_dimension]` and returns `[N_atoms, N_etas * N_types]` where N_etas
-    is the number of eta parameters, N_types is the number of types of
+    spatial_dimension]` and returns `[N_atoms, N_etas * N_types]` where `N_etas`
+    is the number of eta parameters, `N_types` is the number of types of
     particles in the system.
   """
   metric = space.canonicalize_displacement_or_metric(displacement_or_metric)
@@ -258,14 +258,14 @@ def angular_symmetry_functions(displacement: DisplacementFn,
       extension.
     lam:
     zeta:
-    cutoff_distance: Neighbors whose distance is larger than cutoff_distance do
+    cutoff_distance: Neighbors whose distance is larger than `cutoff_distance` do
       not contribute to each others symmetry functions. The contribution of a
       neighbor to the symmetry function and its derivative goes to zero at this
       distance.
   Returns:
     A function that computes the angular symmetry function from input `[N_atoms,
     spatial_dimension]` and returns `[N_atoms, N_types * (N_types + 1) / 2]`
-    where N_types is the number of types of particles in the system.
+    where `N_types` is the number of types of particles in the system.
   """
 
   _angular_fn = vmap(single_pair_angular_symmetry_function,
@@ -326,14 +326,14 @@ def angular_symmetry_functions_neighbor_list(
       extension.
     lam:
     zeta:
-    cutoff_distance: Neighbors whose distance is larger than cutoff_distance do
+    cutoff_distance: Neighbors whose distance is larger than `cutoff_distance` do
       not contribute to each others symmetry functions. The contribution of a
       neighbor to the symmetry function and its derivative goes to zero at this
       distance.
   Returns:
     A function that computes the angular symmetry function from input
     `[N_atoms, spatial_dimension]` and returns
-    `[N_atoms, N_types * (N_types + 1) / 2]` where N_types is the number of
+    `[N_atoms, N_types * (N_types + 1) / 2]` where `N_types` is the number of
     types of particles in the system.
   """
 
@@ -526,7 +526,7 @@ class GraphsTuple(object):
     """A struct containing graph data.
 
     Attributes:
-      nodes: For a graph with N_nodes, this is an `[N_nodes, node_dimension]`
+      nodes: For a graph with `N_nodes`, this is an `[N_nodes, node_dimension]`
         array containing the state of each node in the graph.
       edges: For a graph whose degree is bounded by max_degree, this is an
         `[N_nodes, max_degree, edge_dimension]`. Here `edges[i, j]` is the

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -64,7 +64,7 @@ MaskFn = Callable[[Array], Array]
 class CellList:
   """Stores the spatial partition of a system into a cell list.
 
-  See cell_list(...) for details on the construction / specification.
+  See :meth:`cell_list` for details on the construction / specification.
   Cell list buffers all have a common shape, S, where
     * `S = [cell_count_x, cell_count_y, cell_capacity]`
     * `S = [cell_count_x, cell_count_y, cell_count_z, cell_capacity]`

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -75,7 +75,7 @@ class CellList:
     position_buffer: An ndarray of floating point positions with shape
       `S + [spatial_dimension]`.
     id_buffer: An ndarray of int32 particle ids of shape `S`. Note that empty
-      slots are specified by `id = N` where N is the number of particles in the
+      slots are specified by `id = N` where `N` is the number of particles in the
       system.
     kwarg_buffers: A dictionary of ndarrays of shape `S + [...]`. This contains
       side data placed into the cell list.
@@ -261,7 +261,7 @@ def cell_list(box_size: Box,
   will be set to True.
 
   Args:
-    box_size: A float or an ndarray of shape [spatial_dimension] specifying the
+    box_size: A float or an ndarray of shape `[spatial_dimension]` specifying the
       size of the system. Note, this code is written for the case where the
       boundaries are periodic. If this is not the case, then the current code
       will be slightly less efficient.
@@ -596,28 +596,28 @@ def neighbor_list(displacement_or_metric: DisplacementOrMetricFn,
     displacement: A function `d(R_a, R_b)` that computes the displacement
       between pairs of points.
     box_size: Either a float specifying the size of the box or an array of
-      shape [spatial_dim] specifying the box size in each spatial dimension.
+      shape `[spatial_dim]` specifying the box size in each spatial dimension.
     r_cutoff: A scalar specifying the neighborhood radius.
     dr_threshold: A scalar specifying the maximum distance particles can move
       before rebuilding the neighbor list.
     capacity_multiplier: A floating point scalar specifying the fractional
       increase in maximum neighborhood occupancy we allocate compared with the
       maximum in the example positions.
-    disable_cell_list: An optional boolean. If set to True then the neighbor
+    disable_cell_list: An optional boolean. If set to `True` then the neighbor
       list is constructed using only distances. This can be useful for
-      debugging but should generally be left as False.
+      debugging but should generally be left as `False`.
     mask_self: An optional boolean. Determines whether points can consider
       themselves to be their own neighbors.
     custom_mask_function: An optional function. Takes the neighbor array
       and masks selected elements. Note: The input array to the function is
-      (n_particles, m) where the index of particle 1 is in index in the first
+      `(n_particles, m)` where the index of particle 1 is in index in the first
       dimension of the array, the index of particle 2 is given by the value in
       the array
     fractional_coordinates: An optional boolean. Specifies whether positions
-      will be supplied in fractional coordinates in the unit cube, [0, 1]^d.
-      If this is set to True then the box_size will be set to 1.0 and the
-      cell size used in the cell list will be set to cutoff / box_size.
-    format: The format of the neighbor list; see the NeighborListFormat enum
+      will be supplied in fractional coordinates in the unit cube, :math:`[0, 1]^d`.
+      If this is set to True then the `box_size` will be set to `1.0` and the
+      cell size used in the cell list will be set to `cutoff / box_size`.
+    format: The format of the neighbor list; see the :meth:`NeighborListFormat` enum
       for details about the different choices for formats. Defaults to `Dense`.
     **static_kwargs: kwargs that get threaded through the calculation of
       example positions.

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -73,9 +73,9 @@ class CellList:
 
   Attributes:
     position_buffer: An ndarray of floating point positions with shape
-      S + [spatial_dimension].
-    id_buffer: An ndarray of int32 particle ids of shape S. Note that empty
-      slots are specified by id = N where N is the number of particles in the
+      `S + [spatial_dimension]`.
+    id_buffer: An ndarray of int32 particle ids of shape `S`. Note that empty
+      slots are specified by `id = N` where N is the number of particles in the
       system.
     kwarg_buffers: A dictionary of ndarrays of shape `S + [...]`. This contains
       side data placed into the cell list.
@@ -271,7 +271,7 @@ def cell_list(box_size: Box,
       estimated cell capacity to allow for fluctuations in the maximum cell
       occupancy.
   Returns:
-    A CellListFns object that contains two methods, one to allocate the cell
+    A `CellListFns` object that contains two methods, one to allocate the cell
     list and one to update the cell list. The update function can be called
     with either a cell list from which the capacity can be inferred or with
     an explicit integer denoting the capacity. Note that an existing cell list

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -240,8 +240,8 @@ def cell_list(box_size: Box,
               ) -> CellListFns:
   r"""Returns a function that partitions point data spatially.
 
-  Given a set of points {x_i \in R^d} with associated data {k_i \in R^m} it is
-  often useful to partition the points / data spatially. A simple partitioning
+  Given a set of points :math:`\{x_i \in R^d\}` with associated data :math:`\{k_i \in R^m\}` 
+  it is often useful to partition the points / data spatially. A simple partitioning
   that can be implemented efficiently within XLA is a dense partition into a
   uniform grid called a cell list.
 

--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -77,7 +77,7 @@ class CellList:
     id_buffer: An ndarray of int32 particle ids of shape S. Note that empty
       slots are specified by id = N where N is the number of particles in the
       system.
-    kwarg_buffers: A dictionary of ndarrays of shape S + [...]. This contains
+    kwarg_buffers: A dictionary of ndarrays of shape `S + [...]`. This contains
       side data placed into the cell list.
     did_buffer_overflow: A boolean specifying whether or not the cell list
       exceeded the maximum allocated capacity.

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -151,7 +151,7 @@ def stress(energy_fn: EnergyFn, position: Array, box: Box,
     box: A box specifying the shape of the simulation volume. Used to infer the
       volume of the unit cell.
     mass: The mass of the particles; only used to compute the kinetic
-      contribution if `velocity` is not None.
+      contribution if `velocity` is not `None`.
     velocity: An array of atomic velocities.
 
   Returns:

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -436,10 +436,7 @@ def phop(displacement: DisplacementFn, window_size: int) -> PHopCalculator:
   .. math::
     phop = \sqrt{E_A[(R_i(t) - E_B[R_i(t)])^2]E_B[(R_i(t) - E_A[R_i(t)])^2]}
 
-    R. Candelier et al.
-    "Spatiotemporal Hierarchy of Relaxation Events, Dynamical Heterogeneities,
-     and Structural Reorganization in a Supercooled Liquid"
-    Physical Review Letters 105, 135702 (2010).
+  phop was first introduced in Candelier et al. [#candelier]_
 
   Args:
     displacement: A function that computes displacements between pairs of
@@ -451,6 +448,12 @@ def phop(displacement: DisplacementFn, window_size: int) -> PHopCalculator:
     A pair of functions, `(init_fn, update_fn)` that initialize the state of a
     phop measurement and update the state of a phop measurement to include new
     positions.
+
+  .. rubric:: References
+  .. [#candelier] R. Candelier et al.
+    "Spatiotemporal Hierarchy of Relaxation Events, Dynamical Heterogeneities,
+    and Structural Reorganization in a Supercooled Liquid"
+    Physical Review Letters 105, 135702 (2010).
   """
 
   half_window_size = window_size // 2

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -231,19 +231,24 @@ def pair_correlation(displacement_or_metric: Union[DisplacementFn, MetricFn],
   """Computes the pair correlation function at a mesh of distances.
 
   The pair correlation function measures the number of particles at a given
-  distance from a central particle. The pair correlation function is defined
-  by :math:`g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.` We make the
-  approximation
-  :math:`\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}`.
+  distance from a central particle. The pair correlation function is defined by
+
+  .. math::
+    g(r) = <\sum_{i \\neq j}\delta(r - |r_i - r_j|)>
+  
+  We make the approximation,
+
+  .. math::
+    \delta(r) \\approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}
 
   Args:
-    displacement_or_metric: A function that computes the displacement or
-      distance between two points.
-    radii: An array of radii at which we would like to compute g(r).
+    displacement_or_metric: 
+      A function that computes the displacement or distance between two points.
+    radii: An array of radii at which we would like to compute :math:`g(r)`.
     sigima: A float specifying the width of the approximating Gaussian.
     species: An optional array specifying the species of each particle. If
-      species is None then we compute a single g(r) for all particles,
-      otherwise we compute one g(r) for each species.
+      species is None then we compute a single :math:`g(r)` for all particles,
+      otherwise we compute one :math:`g(r)` for each species.
     eps: A small additive constant used to ensure stability if the radius is
       zero.
 
@@ -295,10 +300,15 @@ def pair_correlation_neighbor_list(
   """Computes the pair correlation function at a mesh of distances.
 
   The pair correlation function measures the number of particles at a given
-  distance from a central particle. The pair correlation function is defined
-  by :math:`g(r) = <\sum_{i\neq j}\delta(r - |r_i - r_j|)>.` We make the
-  approximation,
-  :math:`\delta(r) \approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}`.
+  distance from a central particle. The pair correlation function is defined by 
+  
+  .. math::
+    g(r) = <\sum_{i \\neq j}\delta(r - |r_i - r_j|)>
+  
+  We make the approximation,
+
+  .. math::
+    \delta(r) \\approx {1 \over \sqrt{2\pi\sigma^2}e^{-r / (2\sigma^2)}}
 
   This function uses neighbor lists to speed up the calculation.
 
@@ -306,11 +316,11 @@ def pair_correlation_neighbor_list(
     displacement_or_metric: A function that computes the displacement or
       distance between two points.
     box_size: The size of the box containing the particles.
-    radii: An array of radii at which we would like to compute g(r).
+    radii: An array of radii at which we would like to compute :math:`g(r)`.
     sigima: A float specifying the width of the approximating Gaussian.
     species: An optional array specifying the species of each particle. If
-      species is None then we compute a single g(r) for all particles,
-      otherwise we compute one g(r) for each species.
+      species is None then we compute a single :math:`g(r)` for all particles,
+      otherwise we compute one :math:`g(r)` for each species.
     dr_threshold: A float specifying the halo size of the neighbor list.
     eps: A small additive constant used to ensure stability if the radius is
       zero.
@@ -414,16 +424,17 @@ def phop(displacement: DisplacementFn, window_size: int) -> PHopCalculator:
   in a quiescent system have experienced a rearrangement. Qualitatively, phop
   measures when the average position of a particle has changed significantly.
 
-  Formally, given a window of size \Delta t we two averages before and after
+  Formally, given a window of size :math:`\Delta t` we two averages before and after
   the current time,
 
+  .. math::
     E_A[f] = E_{t\in[t - \Delta t / 2, t]}[f(t)]
     E_B[f] = E_{t\in[t, t + \Delta t / 2]}[f(t)].
 
   In terms of these expectations, phop is given by,
-    phop = \sqrt{E_A[(R_i(t) - E_B[R_i(t)])^2]E_B[(R_i(t) - E_A[R_i(t)])^2]}.
 
-  phop was first introduced in
+  .. math::
+    phop = \sqrt{E_A[(R_i(t) - E_B[R_i(t)])^2]E_B[(R_i(t) - E_A[R_i(t)])^2]}
 
     R. Candelier et al.
     "Spatiotemporal Hierarchy of Relaxation Events, Dynamical Heterogeneities,

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -206,12 +206,12 @@ def cosine_angles(dR: Array) -> Array:
   """Returns cosine of angles for all atom triplets.
 
   Args:
-    dR: Matrix of displacements; ndarray(shape=[num_atoms, num_neighbors,
-      spatial_dim]).
+    dR: Matrix of displacements; `ndarray(shape=[num_atoms, num_neighbors,
+      spatial_dim])`.
 
   Returns:
     Tensor of cosine of angles;
-    ndarray(shape=[num_atoms, num_neighbors, num_neighbors]).
+    `ndarray(shape=[num_atoms, num_neighbors, num_neighbors])`.
   """
 
   angles_between_all_triplets = vmap(

--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -243,21 +243,21 @@ def nose_hoover_chain(dt: float,
 
   This function is used in simulations that sample from thermal ensembles by
   coupling the system to one, or more, Nose-Hoover chains. We use the direct
-  translation method outlined in [1] and the Nose-Hoover chains are updated
+  translation method outlined in Martyna et al. [#martyna92]_ and the Nose-Hoover chains are updated
   using two half steps: one at the beginning of a simulation step and one at
   the end. The masses of the Nose-Hoover chains are updated automatically to
   enforce a specific period of oscillation, `tau`. Larger values of `tau` will
   yield systems that reach the target temperature more slowly but are also more
   stable.
 
-  As described in [1], the Nose-Hoover chain often evolves on a faster
+  As described in Martyna et al. [#martyna92]_, the Nose-Hoover chain often evolves on a faster
   timescale than the rest of the simulation. Therefore, it sometimes necessary
   to integrate the chain over several substeps for each step of MD. To do this
   we follow the Suzuki-Yoshida scheme. Specifically, we subdivide our chain
   simulation into :math:`n_c` substeps. These substeps are further subdivided into
   :math:`n_sy` steps. Each :math:`n_sy` step has length :math:`\delta_i = \Delta t w_i / n_c`
   where :math:`w_i` are constants such that :math:`\sum_i w_i = 1`. See the table of
-  Suzuki_Yoshida weights above for specific values. The number of substeps
+  Suzuki-Yoshida weights above for specific values. The number of substeps
   and the number of Suzuki-Yoshida steps are set using the `chain_steps` and
   `sy_steps` arguments.
 
@@ -418,9 +418,9 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
 
   Samples from the canonical ensemble in which the number of particles (N),
   the system volume (V), and the temperature (T) are held constant. We use a
-  Nose Hoover Chain (NHC) thermostat described in [1, 2, 3]. We follow the
-  direct translation method outlined in [3] and the interested reader might
-  want to look at that paper as a reference.
+  Nose Hoover Chain (NHC) thermostat described in [#martyna92]_ [#martyna98]_ [#tuckerman]_ . 
+  We follow the direct translation method outlined in Tuckerman et al. [#tuckerman]_ 
+  and the interested reader might want to look at that paper as a reference.
 
   Args:
     energy_or_force: A function that produces either an energy or a force from
@@ -444,17 +444,18 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
   Returns:
     See above.
 
-  [1] Martyna, Glenn J., Michael L. Klein, and Mark Tuckerman.
-      "Nose-Hoover chains: The canonical ensemble via continuous dynamics."
-      The Journal of chemical physics 97, no. 4 (1992): 2635-2643.
-  [2] Martyna, Glenn, Mark Tuckerman, Douglas J. Tobias, and Michael L. Klein.
-      "Explicit reversible integrators for extended systems dynamics."
-      Molecular Physics 87. (1998) 1117-1157.
-  [3] Tuckerman, Mark E., Jose Alejandre, Roberto Lopez-Rendon,
-      Andrea L. Jochim, and Glenn J. Martyna.
-      "A Liouville-operator derived measure-preserving integrator for molecular
-      dynamics simulations in the isothermal-isobaric ensemble."
-      Journal of Physics A: Mathematical and General 39, no. 19 (2006): 5629.
+  .. rubric:: References
+  .. [#martyna92] Martyna, Glenn J., Michael L. Klein, and Mark Tuckerman.
+    "Nose-Hoover chains: The canonical ensemble via continuous dynamics."
+    The Journal of chemical physics 97, no. 4 (1992): 2635-2643.
+  .. [#martyna98] Martyna, Glenn, Mark Tuckerman, Douglas J. Tobias, and Michael L. Klein.
+    "Explicit reversible integrators for extended systems dynamics."
+    Molecular Physics 87. (1998) 1117-1157.
+  .. [#tuckerman] Tuckerman, Mark E., Jose Alejandre, Roberto Lopez-Rendon,
+    Andrea L. Jochim, and Glenn J. Martyna.
+    "A Liouville-operator derived measure-preserving integrator for molecular
+    dynamics simulations in the isothermal-isobaric ensemble."
+    Journal of Physics A: Mathematical and General 39, no. 19 (2006): 5629.
   """
   dt = f32(dt)
   if tau is None:
@@ -596,11 +597,12 @@ def npt_nose_hoover(energy_fn: Callable[..., Array],
   """Simulation in the NPT ensemble using a pair of Nose Hoover Chains.
 
   Samples from the canonical ensemble in which the number of particles (N),
-  the system pressure (P), and the temperature (T) are held constant. We use a
-  pair of Nose Hoover Chains (NHC) described in [1, 2, 3] coupled to the
+  the system pressure (P), and the temperature (T) are held constant. 
+  We use a pair of Nose Hoover Chains (NHC) described in 
+  [#martyna92]_ [#martyna98]_ [#tuckerman]_ coupled to the
   barostat and the thermostat respectively. We follow the direct translation
-  method outlined in [3] and the interested reader might want to look at that
-  paper as a reference.
+  method outlined in Tuckerman et al. [#tuckerman]_ and the interested reader 
+  might want to look at that paper as a reference.
 
   Args:
     energy_fn: A function that produces either an energy from a set of particle
@@ -625,17 +627,6 @@ def npt_nose_hoover(energy_fn: Callable[..., Array],
   Returns:
     See above.
 
-  [1] Martyna, Glenn J., Michael L. Klein, and Mark Tuckerman.
-      "Nose-Hoover chains: The canonical ensemble via continuous dynamics."
-      The Journal of chemical physics 97, no. 4 (1992): 2635-2643.
-  [2] Martyna, Glenn, Mark Tuckerman, Douglas J. Tobias, and Michael L. Klein.
-      "Explicit reversible integrators for extended systems dynamics."
-      Molecular Physics 87. (1998) 1117-1157.
-  [3] Tuckerman, Mark E., Jose Alejandre, Roberto Lopez-Rendon,
-      Andrea L. Jochim, and Glenn J. Martyna.
-      "A Liouville-operator derived measure-preserving integrator for molecular
-      dynamics simulations in the isothermal-isobaric ensemble."
-      Journal of Physics A: Mathematical and General 39, no. 19 (2006): 5629.
   """
 
   t = f32(dt)
@@ -859,7 +850,7 @@ def nvt_langevin(energy_or_force: Callable[..., Array],
   ODE described by a friction coefficient and noise of a given covariance.
 
   Our implementation follows the excellent set of lecture notes by Carlon,
-  Laleman, and Nomidis [1].
+  Laleman, and Nomidis [#carlon]_ .
 
   Args:
     energy_or_force: A function that produces either an energy or a force from
@@ -879,9 +870,10 @@ def nvt_langevin(energy_or_force: Callable[..., Array],
   Returns:
     See above.
 
-    [1] E. Carlon, M. Laleman, S. Nomidis. "Molecular Dynamics Simulation."
-        http://itf.fys.kuleuven.be/~enrico/Teaching/molecular_dynamics_2015.pdf
-        Accessed on 06/05/2019.
+  .. rubric:: References
+  .. [#carlon] E. Carlon, M. Laleman, S. Nomidis. "Molecular Dynamics Simulation."
+    http://itf.fys.kuleuven.be/~enrico/Teaching/molecular_dynamics_2015.pdf
+    Accessed on 06/05/2019.
   """
 
   force_fn = quantity.canonicalize_force(energy_or_force)
@@ -960,7 +952,7 @@ def brownian(energy_or_force: Callable[..., Array],
   regime of Langevin dynamics. However, in this case we don't need to take into
   account velocity information and the dynamics simplify. Consequently, when
   Brownian dynamics can be used they will be faster than Langevin. As in the
-  case of Langevin dynamics our implementation follows [1].
+  case of Langevin dynamics our implementation follows Carlon et al. [#carlon]_
 
   Args:
     energy_or_force: A function that produces either an energy or a force from
@@ -978,10 +970,6 @@ def brownian(energy_or_force: Callable[..., Array],
 
   Returns:
     See above.
-
-    [1] E. Carlon, M. Laleman, S. Nomidis. "Molecular Dynamics Simulation."
-        http://itf.fys.kuleuven.be/~enrico/Teaching/molecular_dynamics_2015.pdf
-        Accessed on 06/05/2019.
   """
 
   force_fn = quantity.canonicalize_force(energy_or_force)
@@ -1051,7 +1039,8 @@ def hybrid_swap_mc(space_fns: space.Space,
                    ) -> Simulator:
   """Simulation of Hybrid Swap Monte-Carlo.
 
-  This code simulates the hybrid Swap Monte Carlo algorithm introduced in [1].
+  This code simulates the hybrid Swap Monte Carlo algorithm introduced in 
+  Berthier et al. [#berthier]_
   Here an NVT simulation is performed for `t_md` time and then `N_swap` MC
   moves are performed that swap the radii of randomly chosen particles. The
   random swaps are accepted with Metropolis-Hastings step. Each call to the
@@ -1082,10 +1071,10 @@ def hybrid_swap_mc(space_fns: space.Space,
   Returns:
     See above.
 
-  [1] L. Berthier, E. Flenner, C. J. Fullerton, C. Scalliet, and M. Singh.
-      "Efficient swap algorithms for molecular dynamics simulations of
-       equilibrium supercooled liquids"
-      J. Stat. Mech. (2019) 064004
+  .. rubric:: References
+  .. [#berthier] L. Berthier, E. Flenner, C. J. Fullerton, C. Scalliet, and M. Singh.
+    "Efficient swap algorithms for molecular dynamics simulations of
+    equilibrium supercooled liquids", J. Stat. Mech. (2019) 064004
   """
   displacement_fn, shift_fn = space_fns
   metric_fn = space.metric(displacement_fn)

--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -19,10 +19,13 @@
 
   In general, simulation code follows the same overall structure as optimizers
   in JAX. Simulations are tuples of two functions:
-    init_fn: function that initializes the  state of a system. Should take
-      positions as an ndarray of shape [n, output_dimension]. Returns a state
+
+    init_fn: 
+      Function that initializes the  state of a system. Should take
+      positions as an ndarray of shape `[n, output_dimension]`. Returns a state
       which will be a namedtuple.
-    apply_fn: function that takes a state and produces a new state after one
+    apply_fn: 
+      Function that takes a state and produces a new state after one
       step of optimization.
 
   One question that we need to think about is whether the simulations should
@@ -72,13 +75,12 @@ Simulator = Tuple[InitFn, ApplyFn]
 JAX MD includes integrators for deterministic simulations of the NVE, NVT, and
 NPT ensembles. For a qualitative description of statistical physics ensembles
 see the wikipedia article here:
-
 en.wikipedia.org/wiki/Statistical_ensemble_(mathematical_physics)
 
 Integrators are based direct translation method outlined in the paper,
 
 "A Liouville-operator derived measure-preserving integrator for molecular
- dynamics simulations in the isothermal–isobaric ensemble"
+dynamics simulations in the isothermal–isobaric ensemble"
 
 M. E. Tuckerman, J. Alejandre, R. López-Rendón, A. L Jochim, and G. J. Martyna
 J. Phys. A: Math. Gen. 39 5629 (2006)

--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -127,13 +127,13 @@ class NVEState:
   the (E)nergy of the system are held fixed.
 
   Attributes:
-    position: An ndarray of shape [n, spatial_dimension] storing the position
+    position: An ndarray of shape `[n, spatial_dimension]` storing the position
       of particles.
-    velocity: An ndarray of shape [n, spatial_dimension] storing the velocity
+    velocity: An ndarray of shape `[n, spatial_dimension]` storing the velocity
       of particles.
-    force: An ndarray of shape [n, spatial_dimension] storing the force acting
+    force: An ndarray of shape `[n, spatial_dimension]` storing the force acting
       on particles from the previous step.
-    mass: A float or an ndarray of shape [n] containing the masses of the
+    mass: A float or an ndarray of shape `[n]` containing the masses of the
       particles.
   """
   position: Array
@@ -155,9 +155,9 @@ def nve(energy_or_force_fn: Callable[..., Array],
   Args:
     energy_or_force: A function that produces either an energy or a force from
       a set of particle positions specified as an ndarray of shape
-      [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
     quant: Either a quantity.Energy or a quantity.Force specifying whether
@@ -203,11 +203,11 @@ class NoseHooverChain:
   """State information for a Nose-Hoover chain.
 
   Attributes:
-    position: An ndarray of shape [chain_length] that stores the position of
+    position: An ndarray of shape `[chain_length]` that stores the position of
       the chain.
-    velocity: An ndarray of shape [chain_length] that stores the velocity of
+    velocity: An ndarray of shape `[chain_length]` that stores the velocity of
       the chain.
-    mass: An ndarray of shape [chain_length] that stores the mass of the
+    mass: An ndarray of shape `[chain_length]` that stores the mass of the
       chain.
     tau: The desired period of oscillation for the chain. Longer periods result
       is better stability but worse temperature control.
@@ -388,13 +388,13 @@ class NVTNoseHooverState:
 
   Attributes:
     position: The current position of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     velocity: The velocity of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     force: The current force on the particles. An ndarray of floats with shape
-      [n, spatial_dimension].
+      `[n, spatial_dimension]`.
     mass: The mass of the particles. Can either be a float or an ndarray
-      of floats with shape [n].
+      of floats with shape `[n]`.
     chain: The variables describing the Nose-Hoover chain.
   """
   position: Array
@@ -530,13 +530,13 @@ class NPTNoseHooverState:
 
   Attributes:
     position: The current position of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     velocity: The velocity of particles. An ndarray of floats
-      with shape [n, spatial_dimension].
+      with shape `[n, spatial_dimension]`.
     force: The current force on the particles. An ndarray of floats with shape
-      [n, spatial_dimension].
+      `[n, spatial_dimension]`.
     mass: The mass of the particles. Can either be a float or an ndarray
-      of floats with shape [n].
+      of floats with shape `[n]`.
     reference_box: A box used to measure relative changes to the simulation
       environment.
     box_position: A positional degree of freedom used to describe the current
@@ -602,9 +602,9 @@ def npt_nose_hoover(energy_fn: Callable[..., Array],
 
   Args:
     energy_fn: A function that produces either an energy from a set of particle
-      positions specified as an ndarray of shape [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      positions specified as an ndarray of shape `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
     pressure: Floating point number specifying the target pressure. To update
@@ -826,13 +826,13 @@ class NVTLangevinState:
 
   Attributes:
     position: The current position of the particles. An ndarray of floats with
-      shape [n, spatial_dimension].
+      shape `[n, spatial_dimension]`.
     velocity: The velocity of particles. An ndarray of floats with shape
-      [n, spatial_dimension].
+      `[n, spatial_dimension]`.
     force: The (non-stochastic) force on particles. An ndarray of floats with
-      shape [n, spatial_dimension].
+      shape `[n, spatial_dimension]`.
     mass: The mass of particles. Will either be a float or an ndarray of floats
-      with shape [n].
+      with shape `[n]`.
     rng: The current state of the random number generator.
   """
   position: Array
@@ -963,9 +963,9 @@ def brownian(energy_or_force: Callable[..., Array],
   Args:
     energy_or_force: A function that produces either an energy or a force from
       a set of particle positions specified as an ndarray of shape
-      [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
     kT: Floating point number specifying the temperature in units of Boltzmann
@@ -1026,7 +1026,7 @@ class SwapMCState:
 
   Attributes:
     md: A NVTNoseHooverState containing continuous molecular dynamics data.
-    sigma: An [n,] array of particle radii.
+    sigma: An `[n,]` array of particle radii.
     key: A JAX PRGNKey used for random number generation.
     neighbor: A NeighborList for the system.
   """

--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -160,8 +160,8 @@ def nve(energy_or_force_fn: Callable[..., Array],
       and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
-    quant: Either a quantity.Energy or a quantity.Force specifying whether
-      energy_or_force is an energy or force respectively.
+    quant: Either a quantity. Energy or a quantity. Force specifying whether
+      `energy_or_force` is an energy or force respectively.
   Returns:
     See above.
   """
@@ -274,11 +274,11 @@ def nose_hoover_chain(dt: float,
       simulation.
     chain_length: An integer specifying the number of particles in
       the Nose-Hoover chain.
-    chain_steps: An integer specifying the number, :math:`n_c`, of outer substeps.
+    chain_steps: An integer specifying the number :math:`n_c` of outer substeps.
     sy_steps: An integer specifying the number of Suzuki-Yoshida steps. This
-      must be either 1, 3, 5, or 7.
+      must be either `1`, `3`, `5`, or `7`.
     tau: A floating point timescale over which temperature equilibration occurs.
-      Measured in units of dt. The performance of the Nose-Hoover chain
+      Measured in units of `dt`. The performance of the Nose-Hoover chain
       thermostat can be quite sensitive to this choice.
   Returns:
     A triple of functions that initialize the chain, do a half step of
@@ -423,9 +423,9 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
   Args:
     energy_or_force: A function that produces either an energy or a force from
       a set of particle positions specified as an ndarray of shape
-      [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
     kT: Floating point number specifying the temperature in units of Boltzmann
@@ -435,9 +435,9 @@ def nvt_nose_hoover(energy_or_force_fn: Callable[..., Array],
       the Nose-Hoover chain.
     chain_steps: An integer specifying the number, :math:`n_c`, of outer substeps.
     sy_steps: An integer specifying the number of Suzuki-Yoshida steps. This
-      must be either 1, 3, 5, or 7.
+      must be either `1`, `3`, `5`, or `7`.
     tau: A floating point timescale over which temperature equilibration occurs.
-      Measured in units of dt. The performance of the Nose-Hoover chain
+      Measured in units of `dt`. The performance of the Nose-Hoover chain
       thermostat can be quite sensitive to this choice.
   Returns:
     See above.
@@ -862,9 +862,9 @@ def nvt_langevin(energy_or_force: Callable[..., Array],
   Args:
     energy_or_force: A function that produces either an energy or a force from
       a set of particle positions specified as an ndarray of shape
-      [n, spatial_dimension].
-    shift_fn: A function that displaces positions, R, by an amount dR. Both R
-      and dR should be ndarrays of shape [n, spatial_dimension].
+      `[n, spatial_dimension]`.
+    shift_fn: A function that displaces positions, `R`, by an amount `dR`. Both `R`
+      and `dR` should be ndarrays of shape `[n, spatial_dimension]`.
     dt: Floating point number specifying the timescale (step size) of the
       simulation.
     kT: Floating point number specifying the temperature in units of Boltzmann
@@ -937,9 +937,9 @@ class BrownianState:
 
   Attributes:
     position: The current position of the particles. An ndarray of floats with
-      shape [n, spatial_dimension].
-    mass: The mmass of particles. Will either be a float or an ndarray of floats
-      with shape [n].
+      shape `[n, spatial_dimension]`.
+    mass: The mass of particles. Will either be a float or an ndarray of floats
+      with shape `[n]`.
     rng: The current state of the random number generator.
   """
   position: Array

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -287,10 +287,10 @@ def pair(fn: Callable[..., Array],
       `species` giving the maximum number of types of particles. Note: that
       dynamic species specification is less efficient, because we cannot
       specialize shape information.
-    reduce_axis: A list of axes to reduce over. This is supplied to jnp.sum and
+    reduce_axis: A list of axes to reduce over. This is supplied to `jnp.sum` and
       so the same convention is used.
     keepdims: A boolean specifying whether the empty dimensions should be kept
-      upon reduction. This is supplied to jnp.sum and so the same convention is
+      upon reduction. This is supplied to `jnp.sum` and so the same convention is
       used.
     ignore_unused_parameters: A boolean that denotes whether dynamically
       specified keyword arguments passed to the mapped function get ignored
@@ -506,7 +506,7 @@ def pair_neighbor_list(fn: Callable[..., Array],
       0 corresponds to the particles, axis 1 corresponds to neighbors, and the
       remaining axes correspond to the output axes of `fn`. Note that it is not
       well-defined to sum over particles without summing over neighbors. One
-      also cannot report per-particle values (excluding axis 0) for neighbor
+      also cannot report per-particle values (excluding axis `0`) for neighbor
       lists whose format is `OrderedSparse`.
     ignore_unused_parameters: A boolean that denotes whether dynamically
       specified keyword arguments passed to the mapped function get ignored
@@ -634,7 +634,7 @@ def triplet(fn: Callable[..., Array],
         max_species] defining triplet interactions.
 
   Returns:
-    A function fn_mapped.
+    A function `fn_mapped`.
 
     If species is None or statically specified, then `fn_mapped` takes as
     arguments an ndarray of positions of shape `[n, spatial_dimension]`.

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -96,18 +96,18 @@ def bond(fn: Callable[..., Array],
 
   Args:
     fn: A function that takes an ndarray of pairwise distances or displacements
-      of shape [n, m] or [n, m, d_in] respectively as well as kwargs specifying
-      parameters for the function. fn returns an ndarray of evaluations of shape
-      [n, m, d_out].
+      of shape `[n, m]` or `[n, m, d_in]` respectively as well as kwargs specifying
+      parameters for the function. `fn` returns an ndarray of evaluations of shape
+      `[n, m, d_out]`.
     metric: A function that takes two ndarray of positions of shape
-      [spatial_dimension] and [spatial_dimension] respectively and returns
-      an ndarray of distances or displacements of shape [] or [d_in]
+      `[spatial_dimension]` and `[spatial_dimension]` respectively and returns
+      an ndarray of distances or displacements of shape `[]` or `[d_in]`
       respectively. The metric can optionally take a floating point time as a
       third argument.
-    static_bonds: An ndarray of integer pairs wth shape [b, 2] where each pair
-      specifies a bond. static_bonds are baked into the returned compute
+    static_bonds: An ndarray of integer pairs wth shape `[b, 2]` where each pair
+      specifies a bond. `static_bonds` are baked into the returned compute
       function statically and cannot be changed after the fact.
-    static_bond_types: An ndarray of integers of shape [b] specifying the type
+    static_bond_types: An ndarray of integers of shape `[b]` specifying the type
       of each bond. Only specify bond types if you want to specify bond
       parameters by type. One can also specify constant or per-bond parameters
       (see below).
@@ -272,17 +272,17 @@ def pair(fn: Callable[..., Array],
 
   Args:
     fn: A function that takes an ndarray of pairwise distances or displacements
-      of shape [n, m] or [n, m, d_in] respectively as well as kwargs specifying
+      of shape `[n, m]` or `[n, m, d_in]` respectively as well as kwargs specifying
       parameters for the function. fn returns an ndarray of evaluations of shape
-      [n, m, d_out].
+      `[n, m, d_out]`.
     metric: A function that takes two ndarray of positions of shape
-      [spatial_dimension] and [spatial_dimension] respectively and returns
-      an ndarray of distances or displacements of shape [] or [d_in]
+      `[spatial_dimension]` and `[spatial_dimension]` respectively and returns
+      an ndarray of distances or displacements of shape `[]` or `[d_in]`
       respectively. The metric can optionally take a floating point time as a
       third argument.
     species: A list of species for the different particles. This should either
       be None (in which case it is assumed that all the particles have the same
-      species), an integer ndarray of shape [n] with species data, or an
+      species), an integer ndarray of shape `[n]` with species data, or an
       integer in which case the species data will be specified dynamically with
       `species` giving the maximum number of types of particles. Note: that
       dynamic species specification is less efficient, because we cannot
@@ -309,11 +309,11 @@ def pair(fn: Callable[..., Array],
   Returns:
     A function fn_mapped.
 
-    If species is None or statically specified then fn_mapped takes as arguments
-    an ndarray of positions of shape [n, spatial_dimension].
+    If species is `None` or statically specified then `fn_mapped` takes as arguments
+    an ndarray of positions of shape `[n, spatial_dimension]`.
 
-    If species is dynamic then fn_mapped takes as input an ndarray of shape
-    [n, spatial_dimension], an integer ndarray of species of shape [n], and an
+    If species is dynamic then `fn_mapped` takes as input an ndarray of shape
+    `[n, spatial_dimension]`, an integer ndarray of species of shape `[n]`, and an
     integer specifying the maximum species.
 
     The mapped function can also optionally take keyword arguments that get
@@ -489,17 +489,17 @@ def pair_neighbor_list(fn: Callable[..., Array],
 
   Args:
     fn: A function that takes an ndarray of pairwise distances or displacements
-      of shape [n, m] or [n, m, d_in] respectively as well as kwargs specifying
+      of shape `[n, m]` or `[n, m, d_in]` respectively as well as kwargs specifying
       parameters for the function. fn returns an ndarray of evaluations of
-      shape [n, m, d_out].
+      shape `[n, m, d_out]`.
     metric: A function that takes two ndarray of positions of shape
-      [spatial_dimension] and [spatial_dimension] respectively and returns
-      an ndarray of distances or displacements of shape [] or [d_in]
+      `[spatial_dimension]` and `[spatial_dimension]` respectively and returns
+      an ndarray of distances or displacements of shape `[]` or `[d_in]`
       respectively. The metric can optionally take a floating point time as a
       third argument.
     species: Species information for the different particles. Should either
       be None (in which case it is assumed that all the particles have the same
-      species), an integer array of shape [n] with species data. Note that
+      species), an integer array of shape `[n]` with species data. Note that
       species data can be specified dynamically by passing a `species` keyword
       argument to the mapped function.
     reduce_axis: A list of axes to reduce over. We use a convention where axis
@@ -522,8 +522,8 @@ def pair_neighbor_list(fn: Callable[..., Array],
       shape [max_species, max_species].
 
   Returns:
-    A function fn_mapped that takes an ndarray of floats of shape [N, d_in] of
-    positions and and ndarray of integers of shape [N, max_neighbors]
+    A function `fn_mapped` that takes an ndarray of floats of shape `[N, d_in]` of
+    positions and and ndarray of integers of shape `[N, max_neighbors]`
     specifying neighbors.
   """
   kwargs, param_combinators = _split_params_and_combinators(kwargs)
@@ -601,16 +601,16 @@ def triplet(fn: Callable[..., Array],
 
   Args:
     fn: A function that takes an ndarray of two distances or displacements
-        from a central atom, both of shape [n, m] or [n, m, d_in] respectively,
+        from a central atom, both of shape `[n, m]` or `[n, m, d_in]` respectively,
         as well as kwargs specifying parameters for the function.
     metric: A function that takes two ndarray of positions of shape
-        [spatial_dimensions] and [spatial_dimensions] respectively and
-        returns an ndarray of distances or displacements of shape [] or [d_in]
+        `[spatial_dimensions]` and `[spatial_dimensions]` respectively and
+        returns an ndarray of distances or displacements of shape `[]` or `[d_in]`
         respectively. The metric can optionally take a floating point time as a
         third argument.
     species: A list of species for the different particles. This should either
       be None (in which case it is assumed that all the particles have the same
-      species), an integer ndarray of shape [n] with species data, or an
+      species), an integer ndarray of shape `[n]` with species data, or an
       integer in which case the species data will be specified dynamically with
       `species` giving the maximum number of types of particles. Note: that
       dynamic species specification is less efficient, because we cannot
@@ -636,11 +636,11 @@ def triplet(fn: Callable[..., Array],
   Returns:
     A function fn_mapped.
 
-    If species is None or statically specified, then fn_mapped takes as
-    arguments an ndarray of positions of shape [n, spatial_dimension].
+    If species is None or statically specified, then `fn_mapped` takes as
+    arguments an ndarray of positions of shape `[n, spatial_dimension]`.
 
-    If species is dynamic then fn_mapped takes as input an ndarray of shape
-    [n, spatial_dimension], an integer ndarray of species of shape [n], and
+    If species is dynamic then `fn_mapped` takes as input an ndarray of shape
+    `[n, spatial_dimension]`, an integer ndarray of species of shape `[n]`, and
     an integer specifying the maximum species.
 
     The mapped function can also optionally take keyword arguments that get

--- a/jax_md/smap.py
+++ b/jax_md/smap.py
@@ -92,7 +92,7 @@ def bond(fn: Callable[..., Array],
   """Promotes a function that acts on a single pair to one on a set of bonds.
 
   TODO(schsam): It seems like bonds might potentially have poor memory access.
-    Should think about this a bit and potentially optimize.
+  Should think about this a bit and potentially optimize.
 
   Args:
     fn: A function that takes an ndarray of pairwise distances or displacements
@@ -116,14 +116,19 @@ def bond(fn: Callable[..., Array],
       if they were not first specified as keyword arguments when calling
       `smap.bond(...)`.
     kwargs: Arguments providing parameters to the mapped function. In cases
-      where no bond type information is provided these should be either 1) a
-      scalar or 2) an ndarray of shape [b]. If bond type information is
-      provided then the parameters should be specified as either 1) a scalar or
-      2) an ndarray of shape [max_bond_type].
+      where no bond type information is provided these should be either
+
+        1. a scalar
+        2. an ndarray of shape `[b]`. 
+      
+      If bond type information is provided then the parameters should be specified as either
+
+        1. a scalar
+        2. an ndarray of shape `[max_bond_type]`.
 
   Returns:
-    A function fn_mapped. Note that fn_mapped can take arguments bonds and
-    bond_types which will be bonds that are specified dynamically. This will
+    A function `fn_mapped`. Note that `fn_mapped` can take arguments bonds and
+    `bond_types` which will be bonds that are specified dynamically. This will
     incur a recompilation when the number of bonds changes. Improving this
     state of affairs I will leave as a TODO until someone actually uses this
     feature and runs into speed issues.
@@ -297,14 +302,20 @@ def pair(fn: Callable[..., Array],
       if they were not first specified as keyword arguments when calling
       `smap.pair(...)`.
     kwargs: Arguments providing parameters to the mapped function. In cases
-      where no species information is provided these should be either 1) a
-      scalar, 2) an ndarray of shape [n], 3) an ndarray of shape [n, n],
-      3) a binary function that determines how per-particle parameters are to
-      be combined, 4) a binary function as well as a default set of parameters
-      as in 2). If unspecified then this is taken to be the average of the
+      where no species information is provided these should be either 
+
+        1) a scalar 
+        2) an ndarray of shape `[n]`
+        3) an ndarray of shape `[n, n]`,
+        4) a binary function that determines how per-particle parameters are to be combined
+        5) a binary function as well as a default set of parameters as in 2)
+      
+      If unspecified then this is taken to be the average of the
       two per-particle parameters. If species information is provided then the
-      parameters should be specified as either 1) a scalar or 2) an ndarray of
-      shape [max_species, max_species].
+      parameters should be specified as either 
+      
+        1) a scalar 
+        2) an ndarray of shape `[max_species, max_species]`
 
   Returns:
     A function fn_mapped.
@@ -513,14 +524,20 @@ def pair_neighbor_list(fn: Callable[..., Array],
       if they were not first specified as keyword arguments when calling
       `smap.pair_neighbor_list(...)`.
     kwargs: Arguments providing parameters to the mapped function. In cases
-      where no species information is provided these should be either 1) a
-      scalar, 2) an ndarray of shape [n], 3) an ndarray of shape [n, n],
-      3) a binary function that determines how per-particle parameters are to
-      be combined. If unspecified then this is taken to be the average of the
-      two per-particle parameters. If species information is provided then the
-      parameters should be specified as either 1) a scalar or 2) an ndarray of
-      shape [max_species, max_species].
+      where no species information is provided these should be either 
 
+        1) a scalar 
+        2) an ndarray of shape `[n]`
+        3) an ndarray of shape `[n, n]`,
+        4) a binary function that determines how per-particle parameters are to be combined
+      
+      If unspecified then this is taken to be the average of the
+      two per-particle parameters. If species information is provided then the
+      parameters should be specified as either 
+      
+        1) a scalar 
+        2) an ndarray of shape `[max_species, max_species]`
+      
   Returns:
     A function `fn_mapped` that takes an ndarray of floats of shape `[N, d_in]` of
     positions and and ndarray of integers of shape `[N, max_neighbors]`
@@ -625,13 +642,18 @@ def triplet(fn: Callable[..., Array],
       if they were not first specified as keyword arguments when calling
       `smap.triplet(...)`.
     kwargs: Argument providing parameters to the mapped function. In cases
-        where no species information is provided, these should either be 1)
-        a scalar, 2) an ndarray of shape [n] based on the central atom,
-        3) an ndarray of shape [n, n, n] defining triplet interactions.
+        where no species information is provided, these should either be 
+          
+          1) a scalar
+          2) an ndarray of shape `[n]` based on the central atom
+          3) an ndarray of shape `[n, n, n]` defining triplet interactions.
+
         If species information is provided, then the parameters should
-        be specified as either 1) a scalar,  2) an ndarray of shape
-        [max_species], 3) an ndarray of shape [max_species, max_species,
-        max_species] defining triplet interactions.
+        be specified as either 
+        
+          1) a scalar
+          2) an ndarray of shape `[max_species]`
+          3) an ndarray of shape `[max_species, max_species, max_species]` defining triplet interactions.
 
   Returns:
     A function `fn_mapped`.

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -146,11 +146,11 @@ def pairwise_displacement(Ra: Array, Rb: Array) -> Array:
   """Compute a matrix of pairwise displacements given two sets of positions.
 
   Args:
-    Ra: Vector of positions; ndarray(shape=[spatial_dim]).
-    Rb: Vector of positions; ndarray(shape=[spatial_dim]).
+    Ra: Vector of positions; `ndarray(shape=[spatial_dim])`.
+    Rb: Vector of positions; `ndarray(shape=[spatial_dim])`.
 
   Returns:
-    Matrix of displacements; ndarray(shape=[spatial_dim]).
+    Matrix of displacements; `ndarray(shape=[spatial_dim])`.
   """
   if len(Ra.shape) != 1:
     msg = (
@@ -173,9 +173,9 @@ def periodic_displacement(side: Box, dR: Array) -> Array:
     side: Specification of hypercube size. Either,
       (a) float if all sides have equal length.
       (b) ndarray(spatial_dim) if sides have different lengths.
-    dR: Matrix of displacements; ndarray(shape=[..., spatial_dim]).
+    dR: Matrix of displacements; `ndarray(shape=[..., spatial_dim])`.
   Returns:
-    Matrix of wrapped displacements; ndarray(shape=[..., spatial_dim]).
+    Matrix of wrapped displacements; `ndarray(shape=[..., spatial_dim])`.
   """
   return jnp.mod(dR + side * f32(0.5), side) - f32(0.5) * side
 
@@ -184,9 +184,9 @@ def square_distance(dR: Array) -> Array:
   """Computes square distances.
 
   Args:
-    dR: Matrix of displacements; ndarray(shape=[..., spatial_dim]).
+    dR: Matrix of displacements; `ndarray(shape=[..., spatial_dim])`.
   Returns:
-    Matrix of squared distances; ndarray(shape=[...]).
+    Matrix of squared distances; `ndarray(shape=[...])`.
   """
   return jnp.sum(dR ** 2, axis=-1)
 
@@ -195,9 +195,9 @@ def distance(dR: Array) -> Array:
   """Computes distances.
 
   Args:
-    dR: Matrix of displacements; ndarray(shape=[..., spatial_dim]).
+    dR: Matrix of displacements; `ndarray(shape=[..., spatial_dim])`.
   Returns:
-    Matrix of distances; ndarray(shape=[...]).
+    Matrix of distances; `ndarray(shape=[...])`.
   """
   dr = square_distance(dR)
   return safe_mask(dr > 0, jnp.sqrt, dr)

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -15,13 +15,12 @@
 """Spaces in which particles are simulated.
 
 Spaces are pairs of functions containing:
-
-  `displacement_fn(Ra, Rb, **kwargs)`
+  `displacement_fn(Ra, Rb, **kwargs)`:
     Computes displacements between pairs of particles. `Ra` and `Rb` should
-    be ndarrays of shape `[spatial_dim]`. Returns an ndarray of shape
-    `[spatial_dim]`. To compute the displacement over more than one particle
-    at a time see the :meth:`map_product`, :meth:`map_bond`, and :meth:`map_neighbor` functions.
-  `shift_fn(R, dR, **kwargs)`
+    be ndarrays of shape `[spatial_dim]`. Returns an ndarray of shape `[spatial_dim]`. 
+    To compute the displacement over more than one particle at a time see the 
+    :meth:`map_product`, :meth:`map_bond`, and :meth:`map_neighbor` functions.
+  `shift_fn(R, dR, **kwargs)`:
     Moves points at position `R` by an amount `dR`.
 
 Spaces can accept keyword arguments allowing the space to be changed over the
@@ -31,15 +30,15 @@ Although displacement functions are compute the displacement between two
 points, it is often useful to compute displacements between multiple particles
 in a vectorized fashion. To do this we provide three functions: `map_product`,
 `map_bond`, and `map_neighbor`:
-  `map_product` 
+  map_product:
     Computes displacements between all pairs of points such that if
     `Ra` has shape `[n, spatial_dim]` and `Rb` has shape `[m, spatial_dim]` then the
     output has shape `[n, m, spatial_dim]`.
-  `map_bond` 
+  map_bond:
     Computes displacements between all points in a list such that if
     `Ra` has shape `[n, spatial_dim]` and `Rb` has shape `[m, spatial_dim]` then the
     output has shape `[n, spatial_dim]`.
-  `map_neighbor` 
+  map_neighbor:
     Computes displacements between points and all of their
     neighbors such that if `Ra` has shape `[n, spatial_dim]` and `Rb` has shape
     `[n, neighbors, spatial_dim]` then the output has shape
@@ -284,6 +283,7 @@ def periodic_general(box: Box,
   There are a number of ways to parameterize a simulation on :math:`X`.
   `periodic_general` supports two parametrizations of :math:`X` that can be selected
   using the `fractional_coordinates` keyword argument.
+
     1) When `fractional_coordinates=True`, particle positions are stored in the
        unit cube, :math:`u\in U`. Here, the displacement function computes the
        displacement between :math:`x, y \in X` as :math:`d_X(x, y) = Td_U(u, v)` where
@@ -302,7 +302,6 @@ def periodic_general(box: Box,
        slower than `fractional_coordinates=False`. As in 1), the displacement
        function is defined to compute derivatives in :math:`X`. The shift function
        is defined so that :math:`R` and :math:`dR` should both lie in :math:`X`.
-
 
   Example:
   

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -16,31 +16,34 @@
 
 Spaces are pairs of functions containing:
 
-  * `displacement_fn(Ra, Rb, **kwargs)`
-    Computes displacements between pairs of particles. Ra and Rb should
-    be ndarrays of shape [spatial_dim]. Returns an ndarray of shape
-    [spatial_dim]. To compute the displacement over more than one particle
-    at a time see the `map_product`, `map_bond`, and `map_neighbor` functions.
-
-  * `shift_fn(R, dR, **kwargs)` Moves points at position R by an amount dR.
+  `displacement_fn(Ra, Rb, **kwargs)`
+    Computes displacements between pairs of particles. `Ra` and `Rb` should
+    be ndarrays of shape `[spatial_dim]`. Returns an ndarray of shape
+    `[spatial_dim]`. To compute the displacement over more than one particle
+    at a time see the :meth:`map_product`, :meth:`map_bond`, and :meth:`map_neighbor` functions.
+  `shift_fn(R, dR, **kwargs)`
+    Moves points at position `R` by an amount `dR`.
 
 Spaces can accept keyword arguments allowing the space to be changed over the
-course of a simulation. For an example of this use see `periodic_general`.
+course of a simulation. For an example of this use see :meth:`periodic_general`.
 
 Although displacement functions are compute the displacement between two
 points, it is often useful to compute displacements between multiple particles
 in a vectorized fashion. To do this we provide three functions: `map_product`,
-`map_bond`, and `map_neighbor`.
-  * `map_pair` computes displacements between all pairs of points such that if
-    Ra has shape [n, spatial_dim] and Rb has shape `[m, spatial_dim]` then the
+`map_bond`, and `map_neighbor`:
+  `map_product` 
+    Computes displacements between all pairs of points such that if
+    `Ra` has shape `[n, spatial_dim]` and `Rb` has shape `[m, spatial_dim]` then the
     output has shape `[n, m, spatial_dim]`.
-  * `map_bond` computes displacements between all points in a list such that if
-    Ra has shape [n, spatial_dim] and Rb has shape [m, spatial_dim] then the
-    output has shape [n, spatial_dim].
-  * `map_neighbor` computes displacements between points and all of their
-    neighbors such that if Ra has shape [n, spatial_dim] and Rb has shape
-    [n, neighbors, spatial_dim] then the output has shape
-    [n, neighbors, spatial_dim].
+  `map_bond` 
+    Computes displacements between all points in a list such that if
+    `Ra` has shape `[n, spatial_dim]` and `Rb` has shape `[m, spatial_dim]` then the
+    output has shape `[n, spatial_dim]`.
+  `map_neighbor` 
+    Computes displacements between points and all of their
+    neighbors such that if `Ra` has shape `[n, spatial_dim]` and `Rb` has shape
+    `[n, neighbors, spatial_dim]` then the output has shape
+    `[n, neighbors, spatial_dim]`.
 """
 
 from typing import Callable, Union, Tuple, Any, Optional

--- a/jax_md/space.py
+++ b/jax_md/space.py
@@ -233,7 +233,7 @@ def periodic(side: Box, wrapped: bool=True) -> Space:
     wrapped: A boolean specifying whether or not particle positions are
       remapped back into the box after each step
   Returns:
-    (displacement_fn, shift_fn) tuple.
+    `(displacement_fn, shift_fn)` tuple.
   """
   def displacement_fn(Ra: Array, Rb: Array,
                       perturbation: Optional[Array] = None,
@@ -345,7 +345,7 @@ def periodic_general(box: Box,
     wrapped: A boolean specifying whether or not particle positions are
       remapped back into the box after each step
   Returns:
-    (displacement_fn, shift_fn) tuple.
+    `(displacement_fn, shift_fn)` tuple.
   """
   inv_box = inverse(box)
 


### PR DESCRIPTION
This PR adds several fixes to the docstrings. I've tried to make the commits somewhat atomic so that you can pick the changes you like.

### Changes
* Fix the indentation such that e.g. parameters render correctly
* Some LaTeX math fixes I missed in #182
* Format function names, e.g. "Function foo" to "Function `foo`"
* Format shapes, e.g. "Array of size [n, m]" to "Array of size `[n, m]`"
* Use footnotes for references
* Add links from convenience wrappers to docstring of wrapped potentials
* Remove duplicate docstrings from convenience wrappers
* Remove the non-existent function `bks_silica` from the docs build

### Example
After PR:
<img width="684" alt="Screenshot 2022-04-25 at 16 08 16" src="https://user-images.githubusercontent.com/20258504/165107481-c830c71b-5fa8-442c-aa91-6245b9e7be37.png">
Before PR:
<img width="721" alt="Screenshot 2022-04-25 at 16 08 27" src="https://user-images.githubusercontent.com/20258504/165107503-8700b535-d979-497c-9e6c-2d3c9d87f020.png">

