### PR TITLE
Improve error message of checking `box_size` type

### DIFF
--- a/jax_md/partition.py
+++ b/jax_md/partition.py
@@ -143,7 +143,8 @@ def _cell_dimensions(spatial_dimension: int,
     elif box_size.ndim == 0:
       cell_count = cells_per_side ** spatial_dimension
     else:
-      raise ValueError('Box must either be a scalar or a vector.')
+      raise ValueError(('Box must be either: a scalar, a vector, or a matrix. '
+                        f'Found {box_size}.'))
   else:
     cell_count = cells_per_side ** spatial_dimension
 


### PR DESCRIPTION
It's also consistent with 
```
  raise ValueError(('Box must be either: a scalar, a vector, or a matrix. '
                    f'Found {box}.'))
```
in `space.py`