### PR TITLE
High precision sum fix

### DIFF
--- a/jax_md/util.py
+++ b/jax_md/util.py
@@ -87,8 +87,18 @@ def high_precision_sum(X: Array,
                        axis: Optional[Union[Iterable[int], int]]=None,
                        keepdims: bool=False):
   """Sums over axes at 64-bit precision then casts back to original dtype."""
+  if jnp.issubdtype(X.dtype, jnp.floating):
+    dtyp = jnp.float64
+  elif jnp.issubdtype(X.dtype, jnp.integer):
+    dtyp = jnp.int64
+  elif jnp.issubdtype(X.dtype, jnp.complexfloating):
+    dtyp = jnp.complex128
+  else:
+    raise TypeError('Can only sum over ints, floats, and complex floats. 
+        Instead got type {}'.format(X.dtype))
+
   return jnp.array(
-      jnp.sum(X, axis=axis, dtype=f64, keepdims=keepdims), dtype=X.dtype)
+      jnp.sum(X, axis=axis, dtype=dtyp, keepdims=keepdims), dtype=X.dtype)
 
 
 def maybe_downcast(x):

--- a/jax_md/util.py
+++ b/jax_md/util.py
@@ -87,15 +87,12 @@ def high_precision_sum(X: Array,
                        axis: Optional[Union[Iterable[int], int]]=None,
                        keepdims: bool=False):
   """Sums over axes at 64-bit precision then casts back to original dtype."""
-  if jnp.issubdtype(X.dtype, jnp.floating):
-    dtyp = jnp.float64
-  elif jnp.issubdtype(X.dtype, jnp.integer):
+  if jnp.issubdtype(X.dtype, jnp.integer):
     dtyp = jnp.int64
   elif jnp.issubdtype(X.dtype, jnp.complexfloating):
     dtyp = jnp.complex128
   else:
-    raise TypeError('Can only sum over ints, floats, and complex floats. 
-        Instead got type {}'.format(X.dtype))
+    dtyp = jnp.float64
 
   return jnp.array(
       jnp.sum(X, axis=axis, dtype=dtyp, keepdims=keepdims), dtype=X.dtype)


### PR DESCRIPTION
Currently, `util.high_precision_sum` always casts to `jnp.float64`, even if it is summing over an array of integers or complex floats. In this pr, `util.high_precision_sum` using `jnp.issubdtype` to check if the array is any int, float, or complex float, and chooses the proper type to upcast to accordingly. 

To ensure backwards compatibility for weird dtypes, the array is always promoted to float64 unless it is an int or complex float.