### PR TITLE
add volume fraction functions

### DIFF
--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -459,6 +459,56 @@ def pair_correlation_neighbor_list(
       return g_R
   return neighbor_fn, g_fn
 
+def nball_unit_volume(spatial_dimension: int) -> float:
+  return jnp.power(jnp.pi, spatial_dimension / 2) / \
+    jnp.exp( jsp.special.gammaln(spatial_dimension / 2 + 1))
+
+def particle_volume(radii: Array, 
+                    spatial_dimension: int, 
+                    particle_count: Array = 1, 
+                    species: Array = None) -> float:
+  """ Calculate the volume of a collection of particles
+
+  Args:
+    radii: array of shape (n,) giving particle radii
+    spatial_dimension: int giving the spatial dimension
+    particle_count: number of particles with each radii. broadcastable to radii.
+    species: list of particle species. If provided, this overrides 
+      particle_count.
+  
+  Returns: the sum of the volume of all the particles
+  """
+  V_unit = nball_unit_volume(spatial_dimension)
+  V_particle = V_unit * jnp.power(radii, spatial_dimension)
+
+  if species is not None:
+    particle_count = jnp.bincount(species)
+
+  return jnp.sum(particle_count * V_particle)
+
+def volume_fraction(box: Box, 
+                    radii: Array, 
+                    spatial_dimension: int, 
+                    particle_count: Array = 1, 
+                    species: Array = None) -> float:
+  """ Calculate the volume fraction
+
+  See documentation for particle_volume for explanation of parameters
+  """
+  Vparticle = particle_volume(radii, spatial_dimension, particle_count, species)
+  return Vparticle / quantity.volume(spatial_dimension, box)
+
+def box_size_at_volume_fraction(volume_fraction: float,
+                                radii: Array,
+                                spatial_dimension: int,
+                                particle_count: Array = 1,
+                                species: Array = None) -> float:
+  """ Calculate box_size to obtain a desired volume fraction
+
+  See documentation for particle_volume for explanation of parameters
+  """
+  Vparticle = particle_volume(radii, spatial_dimension, particle_count, species)
+  return jnp.power( Vparticle / volume_fraction, 1 / spatial_dimension)
 
 def box_size_at_number_density(particle_count: int,
                                number_density: float,

--- a/jax_md/quantity.py
+++ b/jax_md/quantity.py
@@ -460,6 +460,8 @@ def pair_correlation_neighbor_list(
   return neighbor_fn, g_fn
 
 def nball_unit_volume(spatial_dimension: int) -> float:
+  """ Return the volume of a unit sphere in arbitrary dimensions
+  """
   return jnp.power(jnp.pi, spatial_dimension / 2) / \
     jnp.exp( jsp.special.gammaln(spatial_dimension / 2 + 1))
 
@@ -470,16 +472,18 @@ def particle_volume(radii: Array,
   """ Calculate the volume of a collection of particles
 
   Args:
-    radii: array of shape (n,) giving particle radii
+    radii: array of shape (n,) giving particle radii, where n can be 1, the
+      number of species, or the number of particles depending on the values of
+      particle_count and species. 
     spatial_dimension: int giving the spatial dimension
-    particle_count: number of particles with each radii. broadcastable to radii.
+    particle_count: number of particles with each radii. Broadcastable to radii.
     species: list of particle species. If provided, this overrides 
-      particle_count.
+      particle_count and radii is expected to give per-species radii
   
   Returns: the sum of the volume of all the particles
   """
   V_unit = nball_unit_volume(spatial_dimension)
-  V_particle = V_unit * jnp.power(radii, spatial_dimension)
+  V_particle = V_unit * radii**spatial_dimension
 
   if species is not None:
     particle_count = jnp.bincount(species)


### PR DESCRIPTION
This PR adds functionality to calculate volume fractions in arbitrary dimensions. Specifically, it adds the following 4 functions:

- `nball_unit_volume`: calculate the volume of an n-dimensional unit sphere
- `particle_volume`: calculate the total volume of a collection of particles. There are various options for specifying different particle radii (e.g. species, etc.). 
-  `volume_fraction`: calculate the volume fraction, uses `quantity.volume`
- `box_size_at_volume_fraction`: similar to `box_size_at_number_density` but for volume fraction. 

While I did document these functions, a few examples might be useful to explain how to use the parameters `radii`, `particle_count`, and `species` to cover different situations:

- case 1: monodisperse particles

```python
dim = 2
phi = 0.87
radii = 1
N = 100
print(particle_volume(radii, dim, particle_count = N))
box_size = box_size_at_volume_fraction(phi, radii, dim, particle_count = N)
print(box_size)
print(volume_fraction(box_size, radii, dim, particle_count = N))
```
- case 2: specify each radii separately
```python
radii = jnp.linspace(1,1.4,N)
print(particle_volume(radii, dim))
box_size = box_size_at_volume_fraction(phi, radii, dim)
print(box_size)
print(volume_fraction(box_size, radii, dim))
```
- case 3: species but with equal concentrations
```python
radii = jnp.array([1,1.1,1.2,1.3,1.4])
particle_count = N // radii.shape[0] #not particle_count = N !
print(particle_volume(radii, dim, particle_count = particle_count))
box_size = box_size_at_volume_fraction(phi, radii, dim, particle_count = particle_count)
print(box_size)
print(volume_fraction(box_size, radii, dim, particle_count = particle_count))
```
- case 4: species with unequal concentrations
```python 
radii = jnp.array([1,1.1,1.2,1.3,1.4])
particle_count = jnp.array([18,19,20,21,22])
print(particle_volume(radii, dim, particle_count = particle_count))
box_size = box_size_at_volume_fraction(phi, radii, dim, particle_count = particle_count)
print(box_size)
print(volume_fraction(box_size, radii, dim, particle_count = particle_count))
```
- case 5: using a jax-md species array
```python 
radii = jnp.array([1,1.1,1.2,1.3,1.4])
species = random.randint(random.PRNGKey(0), (N,), 0, radii.shape[0])
print(particle_volume(radii, dim, species = species))
box_size = box_size_at_volume_fraction(phi, radii, dim, species = species)
print(box_size)
print(volume_fraction(box_size, radii, dim, species = species))
```

Note: the case 5 cannot be jitted because the size of `jnp.bincount(species)` cannot be determined. This should be fairly easy to work around in practice by manually doing the bincount and then using case 4. 

As always, I'm eager to hear any comments/suggestions.