### PR TITLE
optional thermostat initialization from input momenta

### DIFF
--- a/jax_md/simulate.py
+++ b/jax_md/simulate.py
@@ -158,6 +158,12 @@ def initialize_momenta(state: T, key: Array, kT: float) -> T:
   return state.set(momentum=tree_unflatten(treedef, P))
 
 
+def canonicalize_momenta(state: T, momenta: Optional[Array]) -> T:
+  if momenta is None:
+    return state
+  return state.set(momentum=momenta)
+
+
 @dispatch_by_state
 def momentum_step(state: T, dt: float) -> T:
   """Apply a single step of the time evolution operator for momenta."""
@@ -290,11 +296,15 @@ def nve(energy_or_force_fn, shift_fn, dt=1e-3, **sim_kwargs):
   force_fn = quantity.canonicalize_force(energy_or_force_fn)
 
   @jit
-  def init_fn(key, R, kT, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, kT, mass=f32(1.0), momenta=None, **kwargs):
     force = force_fn(R, **kwargs)
     state = NVEState(R, None, force, mass)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, key, kT)
+    if momenta is None:
+      state = initialize_momenta(state, key, kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   @jit
   def step_fn(state, **kwargs):
@@ -613,14 +623,17 @@ def nvt_nose_hoover(
   thermostat = nose_hoover_chain(dt, chain_length, chain_steps, sy_steps, tau)
 
   @jit
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     _kT = kT if 'kT' not in kwargs else kwargs['kT']
 
     dof = quantity.count_dof(R)
 
     state = NVTNoseHooverState(R, None, force_fn(R, **kwargs), mass, None)
     state = canonicalize_mass(state)
-    state = initialize_momenta(state, key, _kT)
+    if momenta is None:
+      state = initialize_momenta(state, key, _kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
     KE = kinetic_energy(state)
     return state.set(chain=thermostat.initialize(dof, KE, _kT))
 
@@ -809,7 +822,7 @@ def npt_nose_hoover(
   thermostat_kwargs = default_nhc_kwargs(100 * dt, thermostat_kwargs)
   thermostat = nose_hoover_chain(dt, **thermostat_kwargs)
 
-  def init_fn(key, R, box, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, box, mass=f32(1.0), momenta=None, **kwargs):
     N, dim = R.shape
 
     _kT = kT if 'kT' not in kwargs else kwargs['kT']
@@ -839,7 +852,10 @@ def npt_nose_hoover(
       None,
     )  # pytype: disable=wrong-arg-count
     state = canonicalize_mass(state)
-    state = initialize_momenta(state, key, _kT)
+    if momenta is None:
+      state = initialize_momenta(state, key, _kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
     KE = kinetic_energy(state)
     return state.set(
       thermostat=thermostat.initialize(quantity.count_dof(R), KE, _kT)
@@ -1129,13 +1145,17 @@ def nvt_langevin(
   force_fn = quantity.canonicalize_force(energy_or_force_fn)
 
   @jit
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     _kT = kwargs.pop('kT', kT)
     key, split = random.split(key)
     force = force_fn(R, **kwargs)
     state = NVTLangevinState(R, None, force, mass, key)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, split, _kT)
+    if momenta is None:
+      state = initialize_momenta(state, split, _kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   @jit
   def step_fn(state, **kwargs):
@@ -1446,11 +1466,15 @@ def temp_rescale(
     new_momentum = tree_map(lambda p: p * lam, state.momentum)
     return state.set(momentum=new_momentum)
 
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     # Reuse the NVEState dataclass
     state = NVEState(R, None, force_fn(R, **kwargs), mass)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, key, kT)
+    if momenta is None:
+      state = initialize_momenta(state, key, kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   def apply_fn(state, **kwargs):
     state = velocity_rescale(state, window, fraction, kT)
@@ -1506,11 +1530,15 @@ def temp_berendsen(
     new_momentum = tree_map(lambda p: p * lam, state.momentum)
     return state.set(momentum=new_momentum)
 
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     # Reuse the NVEState dataclass
     state = NVEState(R, None, force_fn(R, **kwargs), mass)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, key, kT)
+    if momenta is None:
+      state = initialize_momenta(state, key, kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   def apply_fn(state, **kwargs):
     state = berendsen_update(state, tau, kT, dt)
@@ -1613,13 +1641,17 @@ def nvk(
     )
     return state.set(position=new_position)
 
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     _kT = kwargs.pop('kT', kT)
     key, split = random.split(key)
     # Reuse the NVEState dataclass
     state = NVEState(R, None, force_fn(R, **kwargs), mass)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, split, _kT)
+    if momenta is None:
+      state = initialize_momenta(state, split, _kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   def apply_fn(state, **kwargs):
     _KE = kinetic_energy(state)
@@ -1730,13 +1762,17 @@ def temp_csvr(
     new_momentum = tree_map(lambda p: p * lam, state.momentum)
     return state.set(momentum=new_momentum, rng=key)
 
-  def init_fn(key, R, mass=f32(1.0), **kwargs):
+  def init_fn(key, R, mass=f32(1.0), momenta=None, **kwargs):
     _kT = kwargs.pop('kT', kT)
     key, split = random.split(key)
     # Reuse the NVTLangevinState dataclass
     state = NVTLangevinState(R, None, force_fn(R, **kwargs), mass, key)
     state = canonicalize_mass(state)
-    return initialize_momenta(state, split, _kT)
+    if momenta is None:
+      state = initialize_momenta(state, split, _kT)
+    else:
+      state = canonicalize_momenta(state, momenta)
+    return state
 
   def apply_fn(state, **kwargs):
     state = csvr_update(state, tau, kT, dt)

--- a/tests/simulate_test.py
+++ b/tests/simulate_test.py
@@ -554,6 +554,118 @@ class SimulateTest(test_util.JAXMDTestCase):
   @parameterized.named_parameters(
     test_util.cases_from_list(
       {
+        'testcase_name': f'_dtype={dtype.__name__}',
+        'dtype': dtype,
+      }
+      for dtype in DTYPE
+    )
+  )
+  def test_init_functions_accept_explicit_momenta(self, dtype):
+    key = random.PRNGKey(0)
+    alt_key = random.PRNGKey(1)
+    particle_count = 4
+    spatial_dimension = 2
+
+    R = np.arange(
+      particle_count * spatial_dimension, dtype=dtype
+    ).reshape((particle_count, spatial_dimension))
+    mass = np.array([1.0, 2.0, 3.0, 4.0], dtype=dtype)
+    momenta = np.arange(
+      particle_count * spatial_dimension, dtype=dtype
+    ).reshape((particle_count, spatial_dimension)) / dtype(10.0)
+
+    _, free_shift = space.free()
+    box = np.eye(spatial_dimension, dtype=dtype) * dtype(5.0)
+    _, periodic_shift = space.periodic_general(box)
+
+    free_energy = lambda positions, **kwargs: np.sum(positions**2)
+    periodic_energy = lambda positions, box, **kwargs: np.sum(positions**2)
+
+    thermostat_cases = [
+      ('nve', simulate.nve(free_energy, free_shift, 1e-3)[0], {'kT': dtype(1.0)}),
+      (
+        'nvt_nose_hoover',
+        simulate.nvt_nose_hoover(free_energy, free_shift, 1e-3, dtype(1.0))[0],
+        {},
+      ),
+      (
+        'npt_nose_hoover',
+        simulate.npt_nose_hoover(
+          periodic_energy, periodic_shift, 1e-3, dtype(1.0), dtype(1.0)
+        )[0],
+        {'box': box},
+      ),
+      (
+        'nvt_langevin',
+        simulate.nvt_langevin(
+          free_energy, free_shift, 1e-3, dtype(1.0), gamma=dtype(0.1)
+        )[0],
+        {},
+      ),
+      (
+        'temp_rescale',
+        simulate.temp_rescale(
+          free_energy, free_shift, 1e-3, dtype(1.0), window=dtype(0.2), fraction=dtype(0.5)
+        )[0],
+        {},
+      ),
+      (
+        'temp_berendsen',
+        simulate.temp_berendsen(
+          free_energy, free_shift, 1e-3, dtype(1.0), tau=dtype(0.5)
+        )[0],
+        {},
+      ),
+      ('nvk', simulate.nvk(free_energy, free_shift, 1e-3, dtype(1.0))[0], {}),
+      (
+        'temp_csvr',
+        simulate.temp_csvr(
+          free_energy, free_shift, 1e-3, dtype(1.0), tau=dtype(0.5)
+        )[0],
+        {},
+      ),
+    ]
+
+    for _, init_fn, extra_kwargs in thermostat_cases:
+      state = init_fn(key, R, mass=mass, momenta=momenta, **extra_kwargs)
+      alt_state = init_fn(alt_key, R, mass=mass, momenta=momenta, **extra_kwargs)
+      self.assertAllClose(state.momentum, momenta)
+      self.assertAllClose(state.velocity, momenta / mass[:, None])
+      self.assertAllClose(alt_state.momentum, momenta)
+
+  @parameterized.named_parameters(
+    test_util.cases_from_list(
+      {
+        'testcase_name': f'_dtype={dtype.__name__}',
+        'dtype': dtype,
+      }
+      for dtype in DTYPE
+    )
+  )
+  def test_init_functions_randomize_momenta_when_omitted(self, dtype):
+    R = np.zeros((4, 2), dtype=dtype)
+    mass = np.array([1.0, 2.0, 3.0, 4.0], dtype=dtype)
+    _, shift = space.free()
+    energy_fn = lambda positions, **kwargs: np.sum(positions**2)
+
+    nve_init_fn, _ = simulate.nve(energy_fn, shift, 1e-3)
+    nvt_langevin_init_fn, _ = simulate.nvt_langevin(
+      energy_fn, shift, 1e-3, dtype(1.0), gamma=dtype(0.1)
+    )
+
+    nve_state = nve_init_fn(random.PRNGKey(0), R, kT=dtype(1.0), mass=mass)
+    nve_alt_state = nve_init_fn(random.PRNGKey(1), R, kT=dtype(1.0), mass=mass)
+    self.assertFalse(np.allclose(nve_state.momentum, nve_alt_state.momentum))
+
+    langevin_state = nvt_langevin_init_fn(random.PRNGKey(0), R, mass=mass)
+    langevin_alt_state = nvt_langevin_init_fn(random.PRNGKey(1), R, mass=mass)
+    self.assertFalse(
+      np.allclose(langevin_state.momentum, langevin_alt_state.momentum)
+    )
+
+  @parameterized.named_parameters(
+    test_util.cases_from_list(
+      {
         'testcase_name': '_dim={}_dtype={}'.format(dim, dtype.__name__),
         'spatial_dimension': dim,
         'dtype': dtype,

--- a/tests/simulate_test.py
+++ b/tests/simulate_test.py
@@ -566,9 +566,9 @@ class SimulateTest(test_util.JAXMDTestCase):
     particle_count = 4
     spatial_dimension = 2
 
-    R = np.arange(
-      particle_count * spatial_dimension, dtype=dtype
-    ).reshape((particle_count, spatial_dimension))
+    R = np.arange(particle_count * spatial_dimension, dtype=dtype).reshape(
+      (particle_count, spatial_dimension)
+    )
     mass = np.array([1.0, 2.0, 3.0, 4.0], dtype=dtype)
     momenta = np.arange(
       particle_count * spatial_dimension, dtype=dtype
@@ -582,7 +582,11 @@ class SimulateTest(test_util.JAXMDTestCase):
     periodic_energy = lambda positions, box, **kwargs: np.sum(positions**2)
 
     thermostat_cases = [
-      ('nve', simulate.nve(free_energy, free_shift, 1e-3)[0], {'kT': dtype(1.0)}),
+      (
+        'nve',
+        simulate.nve(free_energy, free_shift, 1e-3)[0],
+        {'kT': dtype(1.0)},
+      ),
       (
         'nvt_nose_hoover',
         simulate.nvt_nose_hoover(free_energy, free_shift, 1e-3, dtype(1.0))[0],
@@ -605,7 +609,12 @@ class SimulateTest(test_util.JAXMDTestCase):
       (
         'temp_rescale',
         simulate.temp_rescale(
-          free_energy, free_shift, 1e-3, dtype(1.0), window=dtype(0.2), fraction=dtype(0.5)
+          free_energy,
+          free_shift,
+          1e-3,
+          dtype(1.0),
+          window=dtype(0.2),
+          fraction=dtype(0.5),
         )[0],
         {},
       ),
@@ -628,7 +637,9 @@ class SimulateTest(test_util.JAXMDTestCase):
 
     for _, init_fn, extra_kwargs in thermostat_cases:
       state = init_fn(key, R, mass=mass, momenta=momenta, **extra_kwargs)
-      alt_state = init_fn(alt_key, R, mass=mass, momenta=momenta, **extra_kwargs)
+      alt_state = init_fn(
+        alt_key, R, mass=mass, momenta=momenta, **extra_kwargs
+      )
       self.assertAllClose(state.momentum, momenta)
       self.assertAllClose(state.velocity, momenta / mass[:, None])
       self.assertAllClose(alt_state.momentum, momenta)


### PR DESCRIPTION
Hi,

it would be nice to get this feature into the upstream. We are using it for SO3LR (https://github.com/general-molecular-simulations/so3lr), and I think it is broadly useful for restart and externally initialized MD workflows in general.

This PR adds an optional `momenta` argument to the momentum-based simulator `init_fn`s.

Why this is useful:

- supports restart and continuation workflows without re-randomizing the kinetic state
- makes it easier to initialize from externally prepared MD states
- stays consistent with jax-md’s internal momentum-based state representation
- preserves existing behavior when `momenta` is not provided

What changed:

- added optional `momenta` support to the relevant simulator initializers
- kept the default Maxwell-Boltzmann initialization path unchanged
- added focused tests for explicit-momenta initialization and the existing random-init path

If there’s a preferred naming convention, narrower simulator scope, or additional test coverage you’d like, I’d be happy to update the PR.