### PR TITLE
Trigger did_buffer_overflow if multi-image neighborlist needs to search more shifts

### DIFF
--- a/jax_md/custom_partition.py
+++ b/jax_md/custom_partition.py
@@ -36,6 +36,7 @@ class NeighborListMultiImage:
     shifts: Integer shift vectors. Sparse: (capacity, dim). Dense: (N, max_neighbors, dim).
       The real-space shift is ``shifts @ box.T``.
     reference_position: Positions when the list was built, shape (N, dim).
+    reference_box: Box when the list was built, shape (dim, dim).
     box: An affine transformation; see ``jax_md.space.periodic_general``.
     search_shifts: Integer image stencil used to build this allocation.
     format: NeighborListFormat.Sparse, OrderedSparse, or Dense.
@@ -51,6 +52,7 @@ class NeighborListMultiImage:
   # Dense: Array[N, max_neighbors, dim]
   shifts: Array  # real-space shift = shifts @ box.T
   reference_position: Array  # [N, dim]
+  reference_box: Array  # [dim, dim]
   box: Array  # [dim, dim]
   search_shifts: Array  # [num_shifts, dim]
   format: NeighborListFormat = dataclasses.static_field()
@@ -412,6 +414,7 @@ def _build_neighbor_list_sparse(
     idx=(receivers, senders),
     shifts=edge_shifts,
     reference_position=position,
+    reference_box=box,
     box=box,
     search_shifts=shifts,
     format=NeighborListFormat.Sparse,
@@ -499,6 +502,7 @@ def _build_neighbor_list_orderedsparse(
     idx=(receivers, senders),
     shifts=edge_shifts,
     reference_position=position,
+    reference_box=box,
     box=box,
     search_shifts=shifts,
     format=NeighborListFormat.OrderedSparse,
@@ -604,6 +608,7 @@ def _build_neighbor_list_dense(
     idx=neighbor_idx,
     shifts=neighbor_shifts,
     reference_position=position,
+    reference_box=box,
     box=box,
     search_shifts=shifts,
     format=NeighborListFormat.Dense,
@@ -888,9 +893,6 @@ def neighbor_list_multi_image(
 
   num_shifts = shifts.shape[0]
 
-  # Displacement threshold for skipping rebuild
-  threshold_sq = (dr_threshold / 2.0) ** 2
-
   # Placeholder for circular reference in NeighborListMultiImage.update
   def update_fn_placeholder(position, neighbors, **kwargs):
     raise NotImplementedError()
@@ -956,16 +958,26 @@ def neighbor_list_multi_image(
   def check_needs_rebuild(
     position: Array,  # [N, dim]
     reference_position: Array,  # [N, dim]
+    box: Array,  # [dim, dim]
+    reference_box: Array,  # [dim, dim]
+    nl_shifts: Array,  # [num_shifts, dim]
   ) -> Array:  # scalar bool
     """Check if maximum displacement exceeds threshold."""
     if fractional_coordinates:
-      pos_new = position @ default_box.T  # [N, dim]
-      pos_old = reference_position @ default_box.T
+      pos_new = position @ box.T  # [N, dim]
+      pos_old = reference_position @ reference_box.T
     else:
       pos_new = position
       pos_old = reference_position
-    max_disp_sq = jnp.max(jnp.sum((pos_new - pos_old) ** 2, axis=-1))
-    return max_disp_sq >= threshold_sq
+    max_atom_disp = jnp.sqrt(jnp.max(jnp.sum((pos_new - pos_old) ** 2, axis=-1)))
+
+    # box deformation moves that periodic image by
+    # shift @ (box - reference_box).T; this can dominate for large shifts
+    shift_delta = nl_shifts @ (box - reference_box).T
+    max_shift_disp = jnp.sqrt(jnp.max(jnp.sum(shift_delta**2, axis=-1)))
+    # any pair displacement can change by at most the motion of both atoms plus
+    # the deformation of its stored periodic image shift.
+    return 2.0 * max_atom_disp + max_shift_disp >= dr_threshold
 
   # Choose update strategy at function creation time (not trace time)
   use_threshold = dr_threshold > 0
@@ -1038,7 +1050,7 @@ def neighbor_list_multi_image(
 
     position = position.astype(neighbors.reference_position.dtype)
 
-    current_box = jnp.asarray(kwargs.get('box', default_box))
+    current_box = jnp.asarray(kwargs.get('box', neighbors.box))
     required_shift_n_max = _compute_shift_n_max(current_box, search_cutoff, pbc)
     allocated_shift_n_max = jnp.max(
       jnp.abs(neighbors.search_shifts), axis=0
@@ -1057,13 +1069,20 @@ def neighbor_list_multi_image(
         ),
       )
 
-    # If box= was provided the geometry has changed; always rebuild.
-    # The displacement threshold only applies when the box is unchanged.
-    if use_threshold and 'box' not in kwargs:
+    if use_threshold:
       return jax.lax.cond(
-        check_needs_rebuild(position, neighbors.reference_position),
+        (
+          shift_range_overflow
+          | check_needs_rebuild(
+            position,
+            neighbors.reference_position,
+            current_box,
+            neighbors.reference_box,
+            neighbors.search_shifts,
+          )
+        ),
         rebuild,
-        lambda pos: neighbors,
+        lambda pos: dataclasses.replace(neighbors, box=current_box),
         position,
       )
 

--- a/jax_md/custom_partition.py
+++ b/jax_md/custom_partition.py
@@ -969,7 +969,9 @@ def neighbor_list_multi_image(
     else:
       pos_new = position
       pos_old = reference_position
-    max_atom_disp = jnp.sqrt(jnp.max(jnp.sum((pos_new - pos_old) ** 2, axis=-1)))
+    max_atom_disp = jnp.sqrt(
+      jnp.max(jnp.sum((pos_new - pos_old) ** 2, axis=-1))
+    )
 
     # box deformation moves that periodic image by
     # shift @ (box - reference_box).T; this can dominate for large shifts

--- a/jax_md/custom_partition.py
+++ b/jax_md/custom_partition.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 from jax_md import dataclasses, partition, space
 from jax_md.partition import NeighborListFormat
-from typing import Callable, Tuple, Union, Optional
+from typing import Callable, Tuple, Union
 
 # Type aliases
 Array = jnp.ndarray
@@ -37,6 +37,7 @@ class NeighborListMultiImage:
       The real-space shift is ``shifts @ box.T``.
     reference_position: Positions when the list was built, shape (N, dim).
     box: An affine transformation; see ``jax_md.space.periodic_general``.
+    search_shifts: Integer image stencil used to build this allocation.
     format: NeighborListFormat.Sparse, OrderedSparse, or Dense.
     max_occupancy: For Sparse: total capacity. For Dense: max_neighbors.
     update_fn: Function to update the neighbor list.
@@ -51,6 +52,7 @@ class NeighborListMultiImage:
   shifts: Array  # real-space shift = shifts @ box.T
   reference_position: Array  # [N, dim]
   box: Array  # [dim, dim]
+  search_shifts: Array  # [num_shifts, dim]
   format: NeighborListFormat = dataclasses.static_field()
   max_occupancy: int = dataclasses.static_field()
   update_fn: Callable[..., 'NeighborListMultiImage'] = (
@@ -185,6 +187,18 @@ def _compute_shift_ranges(
   ranges = [jnp.arange(-n, n + 1) for n in n_max_int]  # List of [2*n+1]
   grids = jnp.meshgrid(*ranges, indexing='ij')
   return jnp.stack([g.ravel() for g in grids], axis=-1)  # [num_shifts, dim]
+
+
+def _compute_shift_n_max(
+  box: Array,  # [dim, dim]
+  r_cutoff: float,
+  pbc: Array,  # [dim]
+) -> Array:  # [dim]
+  """Compute per-axis multi-image shift extents with fixed output shape."""
+  inv_box_T = jnp.linalg.inv(box).T  # [dim, dim]
+  heights = 1.0 / jnp.linalg.norm(inv_box_T, axis=0)  # [dim]
+  n_max = jnp.ceil(r_cutoff / heights).astype(i32)  # [dim]
+  return jnp.where(pbc, n_max, 0)
 
 
 def _compute_distances_sq(
@@ -399,6 +413,7 @@ def _build_neighbor_list_sparse(
     shifts=edge_shifts,
     reference_position=position,
     box=box,
+    search_shifts=shifts,
     format=NeighborListFormat.Sparse,
     did_buffer_overflow=(n_valid > capacity),
     max_occupancy=capacity,
@@ -485,6 +500,7 @@ def _build_neighbor_list_orderedsparse(
     shifts=edge_shifts,
     reference_position=position,
     box=box,
+    search_shifts=shifts,
     format=NeighborListFormat.OrderedSparse,
     did_buffer_overflow=(n_valid > capacity),
     max_occupancy=capacity,
@@ -589,6 +605,7 @@ def _build_neighbor_list_dense(
     shifts=neighbor_shifts,
     reference_position=position,
     box=box,
+    search_shifts=shifts,
     format=NeighborListFormat.Dense,
     did_buffer_overflow=did_overflow,
     max_occupancy=max_neighbors,
@@ -868,7 +885,6 @@ def neighbor_list_multi_image(
   shifts = _compute_shift_ranges(
     default_box, search_cutoff, pbc
   )  # [num_shifts, dim]
-  zero_shift_idx = int(jnp.argmin(jnp.sum(shifts**2, axis=1)))
 
   num_shifts = shifts.shape[0]
 
@@ -906,12 +922,13 @@ def neighbor_list_multi_image(
   else:
     build_nl_fn = _build_neighbor_list_sparse
 
-  def make_build_fn(capacity, nl_shifts, zero_idx):
-    """Create a build function for given capacity and shifts."""
+  def make_build_fn(capacity):
+    """Create a build function for given capacity."""
 
     @jax.jit
-    def build_fn(pos, box):
+    def build_fn(pos, box, nl_shifts):
       shifts_real = nl_shifts @ box.T
+      zero_idx = jnp.argmin(jnp.sum(nl_shifts**2, axis=1))
       return build_nl_fn(
         pos,
         box,
@@ -926,27 +943,12 @@ def neighbor_list_multi_image(
 
     return build_fn
 
-  def get_build_fn(capacity: int, box_override=None):
-    """Get or create a build function for given capacity.
-
-    When ``box_override`` is provided (only from ``allocate_fn``,
-    never inside JIT) the integer shift vectors are recomputed for
-    the new geometry.  These are not cached because different boxes
-    can produce the same shift count but different shift vectors.
-
-    Without ``box_override``, the precomputed shifts for the default
-    box are used and the result is cached by capacity.
-    """
-    if box_override is not None:
-      override_box = jnp.asarray(box_override)
-      nl_shifts = _compute_shift_ranges(override_box, search_cutoff, pbc)
-      zero_idx = int(jnp.argmin(jnp.sum(nl_shifts**2, axis=1)))
-      return make_build_fn(capacity, nl_shifts, zero_idx)
-
+  def get_build_fn(capacity: int):
+    """Get or create a build function for given capacity."""
     if capacity in build_fn_cache:
       return build_fn_cache[capacity]
 
-    build_fn = make_build_fn(capacity, shifts, zero_shift_idx)
+    build_fn = make_build_fn(capacity)
     build_fn_cache[capacity] = build_fn
     return build_fn
 
@@ -988,12 +990,13 @@ def neighbor_list_multi_image(
     N = position.shape[0]
     _extra = extra_capacity if use_dense else N * extra_capacity
     current_box = jnp.asarray(box) if box is not None else default_box
+    nl_shifts = _compute_shift_ranges(current_box, search_cutoff, pbc)
 
     # Probe with geometry-based estimate; retry with 2x on overflow.
     cap = _initial_probe_capacity(N) + _extra
     while True:
-      probe_fn = get_build_fn(cap, box_override=box)
-      probe = probe_fn(position, current_box)
+      probe_fn = get_build_fn(cap)
+      probe = probe_fn(position, current_box, nl_shifts)
       if not probe.did_buffer_overflow:
         break
       cap = cap * 2
@@ -1008,8 +1011,8 @@ def neighbor_list_multi_image(
     if max_occupancy == cap:
       return probe
 
-    build_fn = get_build_fn(max_occupancy, box_override=box)
-    return build_fn(position, current_box)
+    build_fn = get_build_fn(max_occupancy)
+    return build_fn(position, current_box, nl_shifts)
 
   def neighbor_list_fn(
     position: Array,  # [N, dim]
@@ -1035,24 +1038,36 @@ def neighbor_list_multi_image(
 
     position = position.astype(neighbors.reference_position.dtype)
 
-    # Update: reuse existing capacity and precomputed integer shifts.
-    # Real-space shifts (shifts @ box.T) are recomputed inside build_fn
-    # using the traced box argument, so this is safe inside JIT.
     current_box = jnp.asarray(kwargs.get('box', default_box))
+    required_shift_n_max = _compute_shift_n_max(current_box, search_cutoff, pbc)
+    allocated_shift_n_max = jnp.max(
+      jnp.abs(neighbors.search_shifts), axis=0
+    ).astype(i32)
+    shift_range_overflow = jnp.any(required_shift_n_max > allocated_shift_n_max)
+
     capacity = neighbors.max_occupancy
     build_fn = get_build_fn(capacity)
+
+    def rebuild(pos):
+      updated = build_fn(pos, current_box, neighbors.search_shifts)
+      return dataclasses.replace(
+        updated,
+        did_buffer_overflow=(
+          updated.did_buffer_overflow | shift_range_overflow
+        ),
+      )
 
     # If box= was provided the geometry has changed; always rebuild.
     # The displacement threshold only applies when the box is unchanged.
     if use_threshold and 'box' not in kwargs:
       return jax.lax.cond(
         check_needs_rebuild(position, neighbors.reference_position),
-        lambda pos: build_fn(pos, current_box),
+        rebuild,
         lambda pos: neighbors,
         position,
       )
 
-    return build_fn(position, current_box)
+    return rebuild(position)
 
   # Close the circular reference
   update_fn_ref[0] = neighbor_list_fn

--- a/tests/custom_partition_test.py
+++ b/tests/custom_partition_test.py
@@ -951,6 +951,80 @@ class CustomPartitionTest(parameterized.TestCase):
 
     # Box should be stored
     np.testing.assert_array_almost_equal(nbrs.box, box)
+    np.testing.assert_array_almost_equal(nbrs.reference_box, box)
+
+  def test_update_uses_stored_box_for_fractional_threshold(self):
+    """Fractional-coordinate threshold uses the box from allocation."""
+    default_box = jnp.eye(3, dtype=jnp.float32) * 10.0
+    allocated_box = jnp.eye(3, dtype=jnp.float32) * 20.0
+    pos_frac = jnp.array(
+      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
+    )
+    moved_frac = pos_frac.at[0, 0].add(0.03)
+
+    neighbor_fn = neighbor_list_multi_image(
+      None,
+      default_box,
+      1.0,
+      dr_threshold=1.0,
+      format=NeighborListFormat.Sparse,
+      fractional_coordinates=True,
+    )
+    nbrs = neighbor_fn.allocate(pos_frac, box=allocated_box)
+
+    updated = nbrs.update(moved_frac)
+
+    np.testing.assert_array_almost_equal(
+      updated.reference_position, moved_frac
+    )
+    np.testing.assert_array_almost_equal(updated.box, allocated_box)
+    np.testing.assert_array_almost_equal(updated.reference_box, allocated_box)
+
+  def test_update_reuses_neighbor_list_for_small_box_change(self):
+    """Small box changes update current box without refreshing references."""
+    box = jnp.eye(3, dtype=jnp.float32) * 20.0
+    new_box = jnp.eye(3, dtype=jnp.float32) * 20.1
+    pos_frac = jnp.array(
+      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
+    )
+
+    neighbor_fn = neighbor_list_multi_image(
+      None,
+      box,
+      1.0,
+      dr_threshold=1.0,
+      format=NeighborListFormat.Sparse,
+      fractional_coordinates=True,
+    )
+    nbrs = neighbor_fn.allocate(pos_frac, box=box)
+
+    updated = nbrs.update(pos_frac, box=new_box)
+
+    np.testing.assert_array_almost_equal(updated.reference_box, box)
+    np.testing.assert_array_almost_equal(updated.box, new_box)
+
+  def test_update_rebuilds_neighbor_list_for_large_box_change(self):
+    """Large box changes refresh the reference geometry."""
+    box = jnp.eye(3, dtype=jnp.float32) * 20.0
+    new_box = jnp.eye(3, dtype=jnp.float32) * 22.0
+    pos_frac = jnp.array(
+      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
+    )
+
+    neighbor_fn = neighbor_list_multi_image(
+      None,
+      box,
+      1.0,
+      dr_threshold=1.0,
+      format=NeighborListFormat.Sparse,
+      fractional_coordinates=True,
+    )
+    nbrs = neighbor_fn.allocate(pos_frac, box=box)
+
+    updated = nbrs.update(pos_frac, box=new_box)
+
+    np.testing.assert_array_almost_equal(updated.reference_box, new_box)
+    np.testing.assert_array_almost_equal(updated.box, new_box)
 
   def test_dataclass_replace(self):
     """Test that dataclasses.replace works on NeighborListMultiImage."""

--- a/tests/custom_partition_test.py
+++ b/tests/custom_partition_test.py
@@ -957,9 +957,7 @@ class CustomPartitionTest(parameterized.TestCase):
     """Fractional-coordinate threshold uses the box from allocation."""
     default_box = jnp.eye(3, dtype=jnp.float32) * 10.0
     allocated_box = jnp.eye(3, dtype=jnp.float32) * 20.0
-    pos_frac = jnp.array(
-      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
-    )
+    pos_frac = jnp.array([[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32)
     moved_frac = pos_frac.at[0, 0].add(0.03)
 
     neighbor_fn = neighbor_list_multi_image(
@@ -974,9 +972,7 @@ class CustomPartitionTest(parameterized.TestCase):
 
     updated = nbrs.update(moved_frac)
 
-    np.testing.assert_array_almost_equal(
-      updated.reference_position, moved_frac
-    )
+    np.testing.assert_array_almost_equal(updated.reference_position, moved_frac)
     np.testing.assert_array_almost_equal(updated.box, allocated_box)
     np.testing.assert_array_almost_equal(updated.reference_box, allocated_box)
 
@@ -984,9 +980,7 @@ class CustomPartitionTest(parameterized.TestCase):
     """Small box changes update current box without refreshing references."""
     box = jnp.eye(3, dtype=jnp.float32) * 20.0
     new_box = jnp.eye(3, dtype=jnp.float32) * 20.1
-    pos_frac = jnp.array(
-      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
-    )
+    pos_frac = jnp.array([[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32)
 
     neighbor_fn = neighbor_list_multi_image(
       None,
@@ -1007,9 +1001,7 @@ class CustomPartitionTest(parameterized.TestCase):
     """Large box changes refresh the reference geometry."""
     box = jnp.eye(3, dtype=jnp.float32) * 20.0
     new_box = jnp.eye(3, dtype=jnp.float32) * 22.0
-    pos_frac = jnp.array(
-      [[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32
-    )
+    pos_frac = jnp.array([[0.1, 0.1, 0.1], [0.4, 0.4, 0.4]], dtype=jnp.float32)
 
     neighbor_fn = neighbor_list_multi_image(
       None,

--- a/tests/custom_partition_test.py
+++ b/tests/custom_partition_test.py
@@ -1012,6 +1012,28 @@ class CustomPartitionTest(parameterized.TestCase):
     n_edges2 = update_and_count(pos_frac + 0.001, nbrs)
     self.assertGreater(int(n_edges2), 0)
 
+  def test_update_flags_shift_range_growth_without_capacity_overflow(self):
+    """Cell changes that need more periodic images should request realloc."""
+    box = jnp.eye(3, dtype=jnp.float32) * 10.0
+    shrunken_box = jnp.eye(3, dtype=jnp.float32)
+    pos_frac = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+
+    neighbor_fn = neighbor_list_multi_image(
+      None,
+      box,
+      2.5,
+      format=NeighborListFormat.Sparse,
+      fractional_coordinates=True,
+    )
+    nbrs = neighbor_fn.allocate(pos_frac, box=box, extra_capacity=200)
+    self.assertFalse(bool(nbrs.did_buffer_overflow))
+
+    updated = nbrs.update(pos_frac, box=shrunken_box)
+
+    self.assertTrue(bool(updated.did_buffer_overflow))
+    n_edges = int(jnp.sum(updated.idx[0] < len(pos_frac)))
+    self.assertLess(n_edges, updated.max_occupancy)
+
   def test_empty_system(self):
     """Test behavior with a single atom (no neighbors)."""
     box = np.eye(3) * 10.0


### PR DESCRIPTION
Currently, if the box shrinks during simulation (e.g. structure relaxation) the resulting neighbor list can be incorrect if more cell repeats are needed to account for the smaller cell size. This fix, sets `did_buffer_overflow=True` which should prompt the user to rebuild the neighborlist (along with the new cell/repeats) in order to get the correct edges.

## Checklist

- [X] Tests added/updated and passing
- [X] Appropriate labels added to PR
