### PR TITLE
[ty] minimize: fix type errors in minimize module

### DIFF
--- a/jax_md/minimize.py
+++ b/jax_md/minimize.py
@@ -114,9 +114,9 @@ class FireDescentState:
   momentum: Array
   force: Array
   mass: Array
-  dt: float
-  alpha: float
-  n_pos: int
+  dt: Union[float, Array]
+  alpha: Union[float, Array]
+  n_pos: Union[int, Array]
 
 
 def fire_descent(
@@ -250,13 +250,13 @@ class PreconFireDescentState:
   position: Array
   velocity: Array
   force: Array
-  dt: float
-  alpha: float
-  n_pos: int
-  initialized: bool
+  dt: Union[float, Array]
+  alpha: Union[float, Array]
+  n_pos: Union[int, Array]
+  initialized: Union[bool, Array]
   preconditioner_position: PyTree
   preconditioner_previous_position: PyTree
-  preconditioner_previous_initialized: bool
+  preconditioner_previous_initialized: Union[bool, Array]
 
   @property
   def momentum(self) -> Array:
@@ -805,9 +805,9 @@ class FireBoxDescentState:
   box_force: Array
   box_mass: Array
   box_factor: Array
-  dt: float
-  alpha: float
-  n_pos: int
+  dt: Union[float, Array]
+  alpha: Union[float, Array]
+  n_pos: Union[int, Array]
 
 
 def fire_descent_box(
@@ -1038,13 +1038,13 @@ class PreconFireBoxDescentState:
   box_velocity: Array
   box_force: Array
   box_factor: Array
-  dt: float
-  alpha: float
-  n_pos: int
-  initialized: bool
+  dt: Union[float, Array]
+  alpha: Union[float, Array]
+  n_pos: Union[int, Array]
+  initialized: Union[bool, Array]
   preconditioner_position: PyTree
   preconditioner_previous_position: PyTree
-  preconditioner_previous_initialized: bool
+  preconditioner_previous_initialized: Union[bool, Array]
 
   @property
   def momentum(self) -> Array:

--- a/tests/minimize_test.py
+++ b/tests/minimize_test.py
@@ -44,7 +44,7 @@ OPTIMIZATION_STEPS = 10
 STOCHASTIC_SAMPLES = 10
 SPATIAL_DIMENSION = [2, 3]
 
-if jax.config.jax_enable_x64:
+if jax.config.jax_enable_x64:  # ty: ignore[possibly-unbound-attribute]
   DTYPE = [f32, f64]
 else:
   DTYPE = [f32]
@@ -334,7 +334,7 @@ class DynamicsTest(test_util.JAXMDTestCase):
     self.assertAllClose(mu, expected)
 
   def test_precon_fire_descent_matches_ase_trajectory(self):
-    if not jax.config.jax_enable_x64:
+    if not jax.config.jax_enable_x64:  # ty: ignore[possibly-unbound-attribute]
       self.skipTest('ASE trajectory parity requires x64.')
 
     from ase import Atoms
@@ -483,7 +483,9 @@ class FireDescentBoxTest(test_util.JAXMDTestCase):
         neighbor = neighbor.set(
           box=box, shifts=neighbor.shifts.astype(box.dtype)
         )
-      return raw_energy_fn(R, neighbor=neighbor, **kwargs)
+      # The neighbor-list energy function accepts `neighbor` as a keyword,
+      # but its declared Callable return type erases parameter names.
+      return raw_energy_fn(R, neighbor=neighbor, **kwargs)  # ty: ignore[missing-argument, unknown-argument]
 
     self.energy_fn = energy_fn
     self.nbrs = self.neighbor_fn.allocate(self.R, box=self.box)
@@ -571,7 +573,9 @@ class FireDescentBoxTest(test_util.JAXMDTestCase):
         neighbor = neighbor.set(
           box=box, shifts=neighbor.shifts.astype(box.dtype)
         )
-      return raw_energy_fn(R, neighbor=neighbor, **kwargs)
+      # The neighbor-list energy function accepts `neighbor` as a keyword,
+      # but its declared Callable return type erases parameter names.
+      return raw_energy_fn(R, neighbor=neighbor, **kwargs)  # ty: ignore[missing-argument, unknown-argument]
 
     nbrs = neighbor_fn.allocate(R, box=box)
     E_init = float(energy_fn(R, box=box, neighbor=nbrs))


### PR DESCRIPTION
Part of the ty type-checking rollout. Brings `jax_md/minimize.py` and `tests/minimize_test.py` to zero ty diagnostics (31 fixed) with no runtime behavior change.

## Fixes

**Real fixes (25 diagnostics, all `invalid-argument-type`):** widened too-narrow dataclass field annotations in `FireDescentState`, `PreconFireDescentState`, `FireBoxDescentState`, and `PreconFireBoxDescentState` — `dt`/`alpha` to `Union[float, Array]`, `n_pos` to `Union[int, Array]`, `initialized`/`preconditioner_previous_initialized` to `Union[bool, Array]`. These fields hold traced JAX arrays at runtime (`jnp.where`, `jnp.zeros`, `jnp.array(False)` results), so the old scalar annotations were simply wrong. Annotation-only change; `jax.tree_util.register_dataclass` only inspects field metadata, not types.

**Suppressions (6 diagnostics, tests/minimize_test.py only):**
- `possibly-unbound-attribute` x2: `jax.config.jax_enable_x64` — jax's `Config` attributes are attached dynamically; not fixable downstream.
- `missing-argument` + `unknown-argument` x2 (4 total): `raw_energy_fn(R, neighbor=...)` where `raw_energy_fn` comes from `energy.lennard_jones_neighbor_list`. The call is valid at runtime, but the declared `Callable[...]` return type erases parameter names.

## Follow-ups for shared files (not owned by this unit)
- `jax_md/energy.py` / smap: neighbor-list energy functions are typed as plain `Callable`, which drops the `neighbor` keyword parameter. A `Protocol` with a named `neighbor` parameter would let callers drop the ignores added here.

## Tests
- `ty check jax_md/minimize.py tests/minimize_test.py` -> All checks passed (0 diagnostics)
- `JAX_ENABLE_X64=1 pytest tests/minimize_test.py -x -q` -> 23 passed
- `ruff check` / `ruff format --check` -> clean
- Import smoke test of `jax_md.minimize` from the worktree -> ok

Note: the CI `typecheck` job checks the whole project and stays red until all sibling units merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)