### PR TITLE
[ty] nn-misc: fix type errors in nequip/e3nn/mace/gnome

### DIFF
--- a/jax_md/_nn/e3nn_layer.py
+++ b/jax_md/_nn/e3nn_layer.py
@@ -271,7 +271,7 @@ class FullyConnectedTensorProductE3nn(nn.Module):
           f'{tp.irreps_in1[ins.i_in1]},'
           f'{tp.irreps_in2[ins.i_in2]},{tp.irreps_out[ins.i_out]}'
         ),
-        nn.initializers.normal(stddev=ins.weight_std),
+        initializers.normal(stddev=ins.weight_std),
         ins.path_shape,
       )
       for ins in tp.instructions
@@ -302,7 +302,8 @@ class Linear(nn.Module):
       )
 
     if irreps_in is not None:
-      x = IrrepsArray(irreps_in, x)
+      # If `irreps_in` is specified, `x` may be a plain array at runtime.
+      x = IrrepsArray(irreps_in, x)  # ty: ignore[invalid-argument-type]
 
     x = x.remove_nones().simplify()
 
@@ -311,14 +312,14 @@ class Linear(nn.Module):
     w = [
       self.param(
         f'b[{ins.i_out}] {lin.irreps_out[ins.i_out]}',
-        nn.initializers.normal(stddev=ins.weight_std),
+        initializers.normal(stddev=ins.weight_std),
         ins.path_shape,
       )
       if ins.i_in == -1
       else self.param(
         f'w[{ins.i_in},{ins.i_out}] {lin.irreps_in[ins.i_in]},'
         f'{lin.irreps_out[ins.i_out]}',
-        nn.initializers.normal(stddev=ins.weight_std),
+        initializers.normal(stddev=ins.weight_std),
         ins.path_shape,
       )
       for ins in lin.instructions

--- a/jax_md/_nn/gnome.py
+++ b/jax_md/_nn/gnome.py
@@ -16,6 +16,7 @@ from typing import NamedTuple, Tuple
 
 import os
 
+import jax
 from jax.core import ShapedArray
 from jax import eval_shape
 from jax import random

--- a/jax_md/_nn/mace/mace_jax_from_torch.py
+++ b/jax_md/_nn/mace/mace_jax_from_torch.py
@@ -157,8 +157,8 @@ def convert_model(
     callable model via ``nnx.merge(graphdef, state)``.
   """
   from flax import nnx
-  from mace_jax.nnx_utils import state_to_serializable_dict
-  from mace_jax.tools.import_from_torch import import_from_torch
+  from mace_jax.nnx_utils import state_to_serializable_dict  # ty: ignore[unresolved-import]
+  from mace_jax.tools.import_from_torch import import_from_torch  # ty: ignore[unresolved-import]
   from jax_md._nn.mace.model_builder import build_jax_model
 
   config = dict(config)
@@ -199,7 +199,7 @@ def save_model(state, config, path):
   Writes parameters to ``path`` (msgpack) and config to ``path.json``.
   """
   from flax import serialization
-  from mace_jax.nnx_utils import state_to_pure_dict
+  from mace_jax.nnx_utils import state_to_pure_dict  # ty: ignore[unresolved-import]
 
   path = Path(path)
   variables = state_to_pure_dict(state)

--- a/jax_md/_nn/mace/model_builder.py
+++ b/jax_md/_nn/mace/model_builder.py
@@ -8,10 +8,10 @@ from e3nn_jax import Irreps
 
 from flax import nnx
 
-from mace_jax.adapters.nnx import resolve_gate_callable
-from mace_jax.modules import interaction_classes, readout_classes
-from mace_jax.modules.models import MACE, ScaleShiftMACE
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.adapters.nnx import resolve_gate_callable  # ty: ignore[unresolved-import]
+from mace_jax.modules import interaction_classes, readout_classes  # ty: ignore[unresolved-import]
+from mace_jax.modules.models import MACE, ScaleShiftMACE  # ty: ignore[unresolved-import]
+from mace_jax.modules.wrapper_ops import CuEquivarianceConfig  # ty: ignore[unresolved-import]
 
 
 def normalize_cueq_config(

--- a/jax_md/_nn/nequip.py
+++ b/jax_md/_nn/nequip.py
@@ -122,7 +122,7 @@ class NequIPConvolution(nn.Module):
     self,
     node_features: IrrepsArray,
     node_attributes: IrrepsArray,
-    edge_sh: Array,
+    edge_sh: IrrepsArray,
     edge_src: Array,
     edge_dst: Array,
     edge_embedded: Array,

--- a/jax_md/_nn/util.py
+++ b/jax_md/_nn/util.py
@@ -54,7 +54,7 @@ class BetaSwish(nn.Module):
   @nn.compact
   def __call__(self, x):
     features = x.shape[-1]
-    beta = self.param('Beta', nn.initializers.ones, (features,))
+    beta = self.param('Beta', initializers.ones, (features,))
     return x * nn.sigmoid(beta * x)
 
 

--- a/tests/nequip_test.py
+++ b/tests/nequip_test.py
@@ -189,7 +189,9 @@ class NequIPTest(test_util.JAXMDTestCase):
     @jax.jit
     def apply_fn(params, atoms, position, nbrs):
       f = nn_util.neighbor_list_featurizer(displacement)
-      return net.apply(params, f(atoms, pos, nbrs))[0, 0]
+      # `net.apply` returns the model output array here, not the
+      # `(output, variables)` tuple flax's overloads suggest.
+      return net.apply(params, f(atoms, pos, nbrs))[0, 0]  # ty: ignore[invalid-argument-type]
 
     nbrs = neighbor.allocate(pos)
     params = init_fn(random.PRNGKey(c.seed), atoms, pos, nbrs)
@@ -266,7 +268,9 @@ class NequIPTest(test_util.JAXMDTestCase):
     @jax.jit
     def apply_fn(params, atoms, position, nbrs):
       f = nn_util.neighbor_list_featurizer(displacement)
-      return net.apply(params, f(atoms, pos, nbrs))[0, 0]
+      # `net.apply` returns the model output array here, not the
+      # `(output, variables)` tuple flax's overloads suggest.
+      return net.apply(params, f(atoms, pos, nbrs))[0, 0]  # ty: ignore[invalid-argument-type]
 
     nbrs = neighbor.allocate(pos)
     params = init_fn(random.PRNGKey(c.seed), atoms, pos, nbrs)


### PR DESCRIPTION
Part of the ty type-checking rollout. Brings the **nn-misc** unit (nequip, e3nn_layer, mace, gnome, nn util, nequip tests) to zero ty diagnostics (20 resolved; project-wide count drops 498 → 478). No runtime behavior change.

## Real fixes (10)
- `jax_md/_nn/nequip.py` (5): `NequIPConvolution.__call__` annotated `edge_sh: IrrepsArray` instead of `Array` — matches runtime truth (caller passes `e3nn.spherical_harmonics` output); clears 5 `possibly-unbound-attribute` warnings on `.irreps`.
- `jax_md/_nn/e3nn_layer.py` (3): `nn.initializers.normal` → `initializers.normal` using the existing `from jax.nn import initializers` import; runtime-verified `flax.linen.initializers.normal is jax.nn.initializers.normal` (flax re-exports jax's initializers), so init is bit-identical. Clears `unresolved-attribute` on flax's lazy `nn.initializers`.
- `jax_md/_nn/util.py` (1): same for `nn.initializers.ones` → `initializers.ones` (identity verified).
- `jax_md/_nn/gnome.py` (1): added `import jax`. Note: this also fixes a latent pre-existing bug — `jax` was unbound, so `jax.tree_util.tree_map` inside `scale_lr_on_plateau`'s `update_fn` would have raised `NameError` if invoked.

## Suppressions (10)
- `unresolved-import` (7): `mace_jax.*` imports in `mace/model_builder.py` (4) and `mace/mace_jax_from_torch.py` (3) — mace_jax is an optional dependency that conflicts with the dev dependency group and cannot be installed in CI.
- `invalid-argument-type` (3): `e3nn_layer.py` `Linear.__call__` passes `x` to `IrrepsArray(irreps_in, x)` where `x` may legitimately be a plain array at runtime (1); `tests/nequip_test.py` `net.apply(...)[0, 0]` where ty picks flax's tuple-returning `apply` overload (2).

## Tests
- `ty check <7 assigned files>` → 0 diagnostics; project-wide check confirms no new diagnostics introduced (478 = 498 baseline − 20).
- `JAX_ENABLE_X64=1 pytest tests/nequip_test.py -x -q` → 6 passed.
- Import smoke for nequip/e3nn_layer/gnome/util OK; mace files verified via `py_compile` only — `tests/mace_test.py` was NOT run (mace_jax dependency unavailable in this environment).
- `ruff check` and `ruff format --check` clean on all touched files.

## Follow-ups
- None in shared files; all fixes are local to the assigned unit.
- CI `typecheck` job will stay red until all sibling units merge (it checks the whole project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)