### PR TITLE
[ty] openmm-io: fix type errors in mm_forcefields io/nonbonded

### DIFF
--- a/jax_md/mm_forcefields/io/openmm.py
+++ b/jax_md/mm_forcefields/io/openmm.py
@@ -18,19 +18,19 @@ try:
   import openmm.app as app  # type: ignore
   import openmm.unit as unit  # type: ignore
 except ImportError:  # pragma: no cover
-  openmm = None
-  app = None
-  unit = None
+  openmm = None  # ty: ignore[invalid-assignment]
+  app = None  # ty: ignore[invalid-assignment]
+  unit = None  # ty: ignore[invalid-assignment]
 
 try:
   from openmmforcefields.generators import SystemGenerator  # type: ignore
 except ImportError:  # pragma: no cover
-  SystemGenerator = None
+  SystemGenerator = None  # ty: ignore[invalid-assignment]
 
 try:
   import parmed  # type: ignore
 except ImportError:  # pragma: no cover
-  parmed = None
+  parmed = None  # ty: ignore[invalid-assignment]
 
 from jax_md import partition, simulate, space, util
 from jax_md.mm_forcefields.base import (
@@ -139,9 +139,9 @@ class OpenMMSystem(NamedTuple):
   params: Parameters
   box_vectors: Array | None
   nb_options: NonbondedOptions
-  recip_alpha: float | None
+  recip_alpha: Array | None
   recip_grid: Array | None
-  ewald_error_tolerance: float | None
+  ewald_error_tolerance: Array | None
   masses: Array | None
   virtual_sites: VirtualSiteData | None
   constraint_idx: Array | None
@@ -207,7 +207,9 @@ def _charmm_read_box(psf: Any, filename: str) -> Any:
         if segments[0].strip() == 'BOXLZ':
           boxlz = float(segments[1])
   psf.setBox(
-    boxlx * unit.angstroms, boxly * unit.angstroms, boxlz * unit.angstroms
+    boxlx * unit.angstroms,  # ty: ignore[unsupported-operator]
+    boxly * unit.angstroms,  # ty: ignore[unsupported-operator]
+    boxlz * unit.angstroms,  # ty: ignore[unsupported-operator]
   )
   return psf
 
@@ -259,9 +261,13 @@ def load_gromacs_system(
     includeDir='/usr/local/gromacs/share/gromacs/top',
   )
   if nb_method is None:
-    nb_method = app.PME if gro.boxVectors is not None else app.NoCutoff
+    nb_method = (
+      app.PME
+      if gro.boxVectors is not None  # ty: ignore[unresolved-attribute]
+      else app.NoCutoff
+    )
   system = top.createSystem(nonbondedMethod=nb_method, **kwargs)
-  return system, top.topology, positions, gro.boxVectors
+  return system, top.topology, positions, gro.boxVectors  # ty: ignore[unresolved-attribute]
 
 
 # TODO is this necessary/will amoeba be supported?
@@ -320,7 +326,7 @@ def load_generator_system(
     )
 
   create_system_kwargs = create_system_kwargs or {}
-  system = generator.createSystem(
+  system = generator.createSystem(  # ty: ignore[possibly-unbound-attribute]
     topology,
     molecules=molecules,
     nonbondedMethod=nb_method,
@@ -676,7 +682,9 @@ def convert_openmm_system(
           or (int(ny) == 0)
           or (int(nz) == 0)
         ):
-          integrator = openmm.VerletIntegrator(1.0 * unit.femtosecond)
+          integrator = openmm.VerletIntegrator(
+            1.0 * unit.femtosecond  # ty: ignore[unresolved-attribute]
+          )
           platform = openmm.Platform.getPlatformByName('Reference')
           context = openmm.Context(system, integrator, platform)
           context.setPositions(positions)
@@ -771,10 +779,16 @@ def convert_openmm_system(
             * values[:, 1]
             * (
               _eval_nonbonded_switch_integral(
-                r_cut, r_switch_cur, r_cut, values[:, 0]
+                r_cut,  # ty: ignore[invalid-argument-type]
+                r_switch_cur,
+                r_cut,  # ty: ignore[invalid-argument-type]
+                values[:, 0],
               )
               - _eval_nonbonded_switch_integral(
-                r_switch_cur, r_switch_cur, r_cut, values[:, 0]
+                r_switch_cur,
+                r_switch_cur,
+                r_cut,  # ty: ignore[invalid-argument-type]
+                values[:, 0],
               )
             )
           )
@@ -787,9 +801,12 @@ def convert_openmm_system(
             count_c
             * eps_c
             * (
-              _eval_nonbonded_switch_integral(r_cut, r_switch_cur, r_cut, sig_c)
+              _eval_nonbonded_switch_integral(r_cut, r_switch_cur, r_cut, sig_c)  # ty: ignore[invalid-argument-type]
               - _eval_nonbonded_switch_integral(
-                r_switch_cur, r_switch_cur, r_cut, sig_c
+                r_switch_cur,
+                r_switch_cur,
+                r_cut,  # ty: ignore[invalid-argument-type]
+                sig_c,
               )
             )
           )
@@ -978,19 +995,19 @@ def convert_openmm_system(
 
   # TODO jax types?
   nb_options = NonbondedOptions(
-    r_cut=r_cut,
+    r_cut=r_cut,  # ty: ignore[invalid-argument-type]
     dr_threshold=dr_threshold,
     use_soft_lj=use_soft_lj,
-    lj_cap=lj_cap,
+    lj_cap=lj_cap,  # ty: ignore[invalid-argument-type]
     use_shift_lj=use_shift_lj,
-    scale_14_lj=scale_14_lj,
-    scale_14_coul=scale_14_coul,
+    scale_14_lj=scale_14_lj,  # ty: ignore[invalid-argument-type]
+    scale_14_coul=scale_14_coul,  # ty: ignore[invalid-argument-type]
     use_pbc=use_pbc,
     nb_format=format,
     use_periodic_general=use_periodic_general,
     fractional_coordinates=fractional_coordinates,
     disp_coef=disp_coef,
-    r_switch=r_switch,
+    r_switch=r_switch,  # ty: ignore[invalid-argument-type]
   )
 
   # To guard against cases where box vectors are provided, but not used
@@ -1189,6 +1206,6 @@ def virtual_site_fix_state(
   )
   safe_force = jnp.where(mask, jnp.zeros_like(state.force), state.force)
 
-  return state.set(
+  return state.set(  # ty: ignore[unresolved-attribute]
     position=pos, mass=safe_mass, momentum=safe_momentum, force=safe_force
   )

--- a/jax_md/mm_forcefields/nonbonded/electrostatics.py
+++ b/jax_md/mm_forcefields/nonbonded/electrostatics.py
@@ -91,7 +91,7 @@ class CutoffCoulomb(CoulombHandler):
     displacement_fn: DisplacementFn,
     cutoff_fn: CutoffWrapper,
     fractional_coordinates: bool,
-  ) -> tuple[EnergyFn, EnergyFn]:
+  ) -> EnergyFn:
     def pair_energy_map(dr, charge_sq, **unused_kwargs):
       """Compute pairwise coulomb energy."""
       energy = COULOMB_CONSTANT * (charge_sq / dr)
@@ -122,7 +122,7 @@ class CutoffCoulomb(CoulombHandler):
     box_kwarg: BoxKwarg,
     exc_pairs: Array,
     exc_charge_prod: Array,
-    coulomb_fns: CoulombFns,
+    coulomb_fns: EnergyFn,
     return_components: bool = False,
   ) -> Array:
     bond_coul_fn = coulomb_fns


### PR DESCRIPTION
## Unit: openmm-io

Brings `ty check` to **0 diagnostics** (from 28) for the assigned files, with
zero runtime behavior change — only annotations, type-alias usage, and
`# ty: ignore[<rule>]` comments.

Files:
- `jax_md/mm_forcefields/io/openmm.py`
- `jax_md/mm_forcefields/nonbonded/electrostatics.py`

### Real fixes (5)
- **electrostatics.py `CutoffCoulomb.prepare_smap`**: return annotation
  `tuple[EnergyFn, EnergyFn]` → `EnergyFn`. The body returns a single
  `bond_coul_fn`; the tuple annotation was wrong (`invalid-return-type`).
- **electrostatics.py `CutoffCoulomb.energy_smap`**: param `coulomb_fns:
  CoulombFns` (tuple) → `EnergyFn`. The value is invoked as a single callable
  (`call-non-callable`); now matches runtime usage.
- **io/openmm.py `OpenMMSystem`**: `recip_alpha` and `ewald_error_tolerance`
  widened `float | None` → `Array | None`. The constructor stores
  `jnp.asarray(...)` results, so `Array | None` is the accurate type (fixes
  two `invalid-argument-type` at the constructor call).

### `# ty: ignore` suppressions (per rule)
- `invalid-assignment` ×5 — guarded optional-import fallbacks assigning `None`
  to `openmm`, `app`, `unit`, `SystemGenerator`, `parmed`.
- `unsupported-operator` ×3 — `float * unit.angstroms` (openmm `Quantity`
  operator typing unresolved).
- `unresolved-attribute` ×4 — `unit.femtosecond` and `state.set` (the `set`
  method is injected by `jax_md.dataclasses.dataclass` via `setattr`, invisible
  to ty), plus `gro.boxVectors` ×2 (see follow-up).
- `possibly-unbound-attribute` ×1 — `generator.createSystem` on the
  openmmforcefields `SystemGenerator` (no stubs).
- `invalid-argument-type` ×9 — `r_cut`-derived args (`float | None`) passed to
  `_eval_nonbonded_switch_integral`, and `None`-initialized placeholders
  (`r_cut`, `lj_cap`, `scale_14_lj`, `scale_14_coul`, `r_switch`) passed to
  `NonbondedOptions` whose fields are declared `float`.

### Tests run
- `ty check <files> --python $REPO/.venv` → **0 diagnostics**.
- Import smoke (worktree jax_md shadowing confirmed): OK.
- `JAX_ENABLE_X64=1 pytest tests/oplsaa_test.py -x -q` → **6 passed**.
- `ruff check` + `ruff format --check` → clean.

### Follow-ups flagged (shared files I don't own)
- **base.py `NonbondedOptions`**: fields `r_cut`, `lj_cap`, `scale_14_lj`,
  `scale_14_coul`, `r_switch` are declared `float` but the io layer legitimately
  passes `None` (placeholders). Proper fix is to make them `Optional[float]` in
  `jax_md/mm_forcefields/base.py`; suppressed here with inline ignores.
- **dataclasses/simulate**: ty cannot see the `.set` method added dynamically by
  `jax_md.dataclasses.dataclass`. A typed protocol/stub on the dataclass
  transform would remove the need for the `state.set` ignore.
- **Latent runtime bug (pre-existing, NOT fixed here):** `load_gromacs_system`
  references `gro.boxVectors`, but `openmm.app.GromacsGroFile` has no such
  attribute (it stores `self._periodicBoxVectors` and exposes
  `getPeriodicBoxVectors()`), so the call would raise `AttributeError`.
  Suppressed with `# ty: ignore[unresolved-attribute]` to honor the no-logic-
  change mandate; should be fixed separately to call `getPeriodicBoxVectors()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)